### PR TITLE
(feat) remove uppercase formatting

### DIFF
--- a/flex-horseshoe-card.js
+++ b/flex-horseshoe-card.js
@@ -533,7 +533,6 @@ import {
           opacity: 0.8;
           fill : var(--primary-text-color);
           font-size: 1.5em;
-          text-transform: uppercase;
           letter-spacing: 0.1em;
         }
   
@@ -543,7 +542,6 @@ import {
           overflow: hidden;
           fill : var(--primary-text-color);
           text-anchor: middle;
-          text-transform: uppercase;
           letter-spacing: 0.1em;
         }
   


### PR DESCRIPTION
Remove the automatic uppercase formatting for names and area strings. Normal behaviour in HA cards is defined as none, and hence a user input for these fields should be treated as such. Users still have opportunity to capitalize names and areas within their input or through manual 'styles: text-transform: uppercase;'

this commit resolves #9