### PR TITLE
Fix state animation

### DIFF
--- a/flex-horseshoe-card.js
+++ b/flex-horseshoe-card.js
@@ -797,8 +797,15 @@ import {
       if (this.config.animations) Object.keys(this.config.animations).map(animation => {
     const entityIndex = animation.substr(Number(animation.indexOf('.') + 1));
     this.config.animations[animation].map(item => {
+
+      state = this.entities[entityIndex].state.toLowerCase();
+      if ((this.config.entities[entityIndex].attribute)) {
+        var attrState = this.entities[entityIndex].attributes[this.config.entities[entityIndex].attribute];
+        if (attrState) state = attrState.toLowerCase();
+      }
+
       // if animation state not equals sensor state, return... Nothing to animate for this state...
-          if (this.entities[entityIndex].state.toLowerCase() != item.state.toLowerCase()) return;
+      if (state != item.state.toLowerCase()) return;
       
       if (item.vlines) {
       item.vlines.map(item2 => {


### PR DESCRIPTION
Fix for an issue where the background color per state was not applied when defined in an animation block.
(It could be seen also as an enhancement, when the entity specifies an attribute...)
See attached screenshot
![Screenshot 2022-03-04 130511](https://user-images.githubusercontent.com/17415569/156768962-558cc405-0157-472c-9c82-1980236deb74.png)
.