### PR TITLE
add custom starting point of foreground horsehoe

### DIFF
--- a/flex-horseshoe-card.js
+++ b/flex-horseshoe-card.js
@@ -748,13 +748,22 @@ import {
       // Calculate the size of the arc to fill the dasharray with this 
       // value. It will fill the horseshoe relative to the state and min/max
       // values given in the configuration.
+      const min = this.config.horseshoe_scale.min || 0;
+      const max = this.config.horseshoe_scale.max || 100;
+      const start_value = this.config.horseshoe_scale?.start != null ? 
+                   this.config.horseshoe_scale.start : 
+                   min;
+      const start_score = Math.min(this._calculateValueBetween(min, max, start_value), 1);
+
       
-    const min = this.config.horseshoe_scale.min || 0;
-    const max = this.config.horseshoe_scale.max || 100;
-    const val = Math.min(this._calculateValueBetween(min, max, state), 1);
-    const score = val * HORSESHOE_PATH_LENGTH;
-    const total = 10 * HORSESHOE_RADIUS_SIZE;
-    this.dashArray = `${score} ${total}`;
+      var val = Math.min(this._calculateValueBetween(min, max, state), 1);
+
+      val = Math.abs(start_score - val);
+      const score = val * HORSESHOE_PATH_LENGTH;
+
+
+      const total = 10 * HORSESHOE_RADIUS_SIZE;
+      this.dashArray = `${score} ${total}`;
   
       // We must draw the horseshoe. Depending on the stroke settings, we draw a fixed color, gradient, autominmax or colorstop 
       // #TODO: only if state or attribute has changed.
@@ -1112,6 +1121,14 @@ import {
   
     if (!this.config.show.horseshoe) return;
     
+    const min = this.config.horseshoe_scale.min || 0;
+    const max = this.config.horseshoe_scale.max || 100;
+    const start_value = this.config.horseshoe_scale?.start != null ? 
+                   this.config.horseshoe_scale.start : 
+                   min;
+    const start_score = Math.min(this._calculateValueBetween(min, max, start_value), 1);
+    const start_value_angle = -220 + 260 * start_score;
+
     return svg`
         <g id="horseshoe__svg__group" class="horseshoe__svg__group">
           <circle id="horseshoe__scale" class="horseshoe__scale" cx="50%" cy="50%" r="45%"
@@ -1121,14 +1138,23 @@ import {
             stroke-width="${this.config.horseshoe_scale.width || 6}" 
             stroke-linecap="round"
             transform="rotate(-220 100 100)"/>
-  
+
           <circle id="horseshoe__state__value" class="horseshoe__state__value" cx="50%" cy="50%" r="45%"
             fill="${this.config.fill || 'rgba(0, 0, 0, 0)'}"
             stroke="url('#horseshoe__gradient-${this.cardId}')"
-            stroke-dasharray="${this.dashArray}"
+            stroke-dasharray="${this.entities[0].state >= start_value ? this.dashArray : '0,' + 900}"
             stroke-width="${this.config.horseshoe_state.width || 12}" 
             stroke-linecap="round"
-            transform="rotate(-220 100 100)"
+            transform="rotate(${start_value_angle} 100 100)"
+            style="transition: all 2.5s ease-out;"/>
+
+          <circle id="horseshoe__state__value_mirrored" class="horseshoe__state__value" cx="50%" cy="50%" r="45%"
+            fill="${this.config.fill || 'rgba(0, 0, 0, 0)'}"
+            stroke="url('#horseshoe__gradient-${this.cardId}')"
+            stroke-dasharray="${this.entities[0].state < start_value ? this.dashArray : '0,' + 900}"
+            stroke-width="${this.config.horseshoe_state.width || 12}" 
+            stroke-linecap="round"
+            transform="rotate(${start_value_angle + 180} 100 100) scale(-1, 1) translate(-200, 0)"
             style="transition: all 2.5s ease-out;"/>
           
           ${this._renderTickMarks()}

--- a/flex-horseshoe-card.js
+++ b/flex-horseshoe-card.js
@@ -748,11 +748,9 @@ import {
       // Calculate the size of the arc to fill the dasharray with this 
       // value. It will fill the horseshoe relative to the state and min/max
       // values given in the configuration.
-      const min = this.config.horseshoe_scale.min || 0;
-      const max = this.config.horseshoe_scale.max || 100;
-      const start_value = this.config.horseshoe_scale?.start != null ? 
-                   this.config.horseshoe_scale.start : 
-                   min;
+      const min = this.config.horseshoe_scale.min ?? 0;
+      const max = this.config.horseshoe_scale.max ?? 100;
+      const start_value = this.config.horseshoe_scale?.start ?? min;
       const start_score = Math.min(this._calculateValueBetween(min, max, start_value), 1);
 
       
@@ -1120,12 +1118,10 @@ import {
   _renderHorseShoe() {
   
     if (!this.config.show.horseshoe) return;
-    
-    const min = this.config.horseshoe_scale.min || 0;
-    const max = this.config.horseshoe_scale.max || 100;
-    const start_value = this.config.horseshoe_scale?.start != null ? 
-                   this.config.horseshoe_scale.start : 
-                   min;
+
+    const min = this.config.horseshoe_scale.min ?? 0;
+    const max = this.config.horseshoe_scale.max ?? 100;
+    const start_value = this.config.horseshoe_scale?.start ?? min;
     const start_score = Math.min(this._calculateValueBetween(min, max, start_value), 1);
     const start_value_angle = -220 + 260 * start_score;
 

--- a/flex-horseshoe-card.js
+++ b/flex-horseshoe-card.js
@@ -758,7 +758,6 @@ import {
       val = Math.abs(start_score - val);
       const score = val * HORSESHOE_PATH_LENGTH;
 
-
       const total = 10 * HORSESHOE_RADIUS_SIZE;
       this.dashArray = `${score} ${total}`;
   

--- a/flex-horseshoe-card.js
+++ b/flex-horseshoe-card.js
@@ -753,7 +753,6 @@ import {
       const start_value = this.config.horseshoe_scale?.start ?? min;
       const start_score = Math.min(this._calculateValueBetween(min, max, start_value), 1);
 
-      
       var val = Math.min(this._calculateValueBetween(min, max, state), 1);
 
       val = Math.abs(start_score - val);


### PR DESCRIPTION
-added option "start" to "horseshoe_scale"
-if start is not set it will default to the current functionality(starting at the left most point)
-two horseshoes are rendered at the starting point specified(one regular and one mirrored to go in the other direction for values < start)

Note that this will NOT always start in the middle but rather at the starting point value


Examples: (horseshoe value = top number)
```
horseshoe_scale:
  min: -100
  max: 100
  start: 0
```
<img width="481" height="475" alt="m100" src="https://github.com/user-attachments/assets/718e1d6b-fe2f-4a97-9173-d780524699ce" />
<img width="501" height="484" alt="p100" src="https://github.com/user-attachments/assets/c7aaf840-0a8e-4db3-b50b-c72fb7619088" />


```
horseshoe_scale:
  min: -100
  max: 100
  start: 50
```
<img width="492" height="481" alt="s50_m100" src="https://github.com/user-attachments/assets/b2aa901c-329f-4cb0-a21e-2f09e8dcca87" />
<img width="483" height="471" alt="s50_p100" src="https://github.com/user-attachments/assets/4a9719c1-a553-4280-9a8f-e5c43df8f7fd" />


