### PR TITLE
fix: fix hacs manifest file

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Flexible Horseshoe Card for Lovelace",
+  "filename": "flex-horseshoe-card.js",
   "render_readme": true,
-  "content_in_root": false,
-  "filename": "flex-horseshoe-card.js"
+  "content_in_root": false
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flex-horseshoe",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "description": "Flexible Horseshoe Card for Lovelace",
   "main": "src/main.js",
   "type": "module",


### PR DESCRIPTION
Due to a typo in the manifest file and NOT syncing during testing, HACS was not downloading the right version.
