### PR TITLE
Fix negative value duplicated when `decimals` is set (e.g. -3.91 → -3.91-3.91)

### DIFF
--- a/src/state-tool.js
+++ b/src/state-tool.js
@@ -614,9 +614,16 @@ export default class StateTool extends BaseTool {
       }).format(Number(rawValue));
     }
 
+    // `formattedValue` is the complete formatted number (including sign). A negative
+    // value can arrive as several `value` parts (e.g. "-" and "3.91", split by the
+    // currency symbol for monetary entities), so write it to the FIRST value part only
+    // and blank the rest — otherwise every value part is overwritten and the value doubles.
+    let valueApplied = false;
     return parts.map((part) => {
       if (part.type === 'value' && formattedValue !== undefined) {
-        return { ...part, value: formattedValue };
+        const value = valueApplied ? '' : formattedValue;
+        valueApplied = true;
+        return { ...part, value };
       }
 
       if (part.type === 'unit' && this.entityConfig.unit !== undefined) {

--- a/tests/state-tool-decimals.test.js
+++ b/tests/state-tool-decimals.test.js
@@ -101,3 +101,36 @@ test('format decimal bounds override entity decimals last', () => {
 
   assert.equal(tool.state, '10,2');
 });
+
+test('decimals override does not duplicate a negative value split across value parts', () => {
+  const entity = {
+    entity_id: 'sensor.electricity_cost',
+    state: '-3.91',
+    attributes: { device_class: 'monetary', unit_of_measurement: 'GBP' },
+  };
+  const hass = {
+    language: 'en-US',
+    locale: { language: 'en-US', number_format: 'language' },
+    entities: { [entity.entity_id]: { entity_id: entity.entity_id } },
+    states: { [entity.entity_id]: entity },
+    // Negative monetary values arrive as separate value parts: the minus sign and the
+    // number are split by the currency symbol → [value "-", unit "£", value "3.91"].
+    formatEntityStateToParts: () => [
+      { type: 'value', value: '-' },
+      { type: 'unit', value: '£' },
+      { type: 'value', value: '3.91' },
+    ],
+    formatEntityAttributeValueToParts: () => [],
+  };
+  const tool = Object.create(StateTool.prototype);
+  tool.config = { show: { uom: 'end' } };
+  tool.entityConfig = { entity: entity.entity_id, decimals: 2 };
+  tool.entity = entity;
+  tool.card = { _hass: hass };
+  tool.textEllipsis = (value) => value;
+
+  tool.buildStateAndUom();
+
+  assert.equal(tool.state, '-3.91');
+  assert.equal(tool.uom, '£');
+});


### PR DESCRIPTION
## Summary
When a state has a `decimals` override set on the card **and** the value is **negative**, the displayed value is duplicated — e.g. `-3.91` renders as `-3.91-3.91`. For a monetary entity it appears as the number twice around the currency symbol (e.g. `-£3.91` → `-3.91£-3.91`).

## How to reproduce
This needs a specific — but entirely real — combination:
- an entity displayed with the card's **`decimals:`** option set, **and**
- that entity holding a **negative** value.

A concrete real-world case: a **daily electricity cost** tile using `decimals: 2`, on a home that is **net-exporting** (solar surplus) so the daily cost goes **negative** for much of the summer. Positive values render correctly, which is why this stays hidden until a value goes negative — you need both the `decimals` override and a negative value to trip it.

## Root cause
`formatEntityStateParts()` in `src/state-tool.js` overwrites **every** part of type `value` with the full `formattedValue`. A negative value can arrive as **multiple `value` parts**: for monetary entities, `compute_state_display.ts` emits the currency symbol as a `unit` part sitting *between* the minus sign and the number, so `formatEntityStateToParts` returns e.g. `[{type:'value',value:'-'}, {type:'unit',value:'£'}, {type:'value',value:'3.91'}]`. The map then writes `formattedValue` (`"-3.91"`) to **both** value parts, and `buildStateAndUom()` concatenates them → `-3.91-3.91`.

## Fix
`formattedValue` is already the complete signed number, so write it to the **first** `value` part only and blank any subsequent `value` parts.

## Tests
Added a regression test in `tests/state-tool-decimals.test.js` for the negative-monetary (multi `value` part) case: it fails before the change (`-3.91-3.91`) and passes after (`-3.91`). All existing tests still pass (`npm test`).

Before 2.4.7
<img width="387" height="199" alt="image" src="https://github.com/user-attachments/assets/fbbb9084-9d7e-49d8-88bf-9940cdebe6b8" />

After on 2.4.7-dev.24 + fix (also linear_gradient vs lineargradient gradient break in dev.24)
<img width="385" height="194" alt="image" src="https://github.com/user-attachments/assets/bdaff6e9-762e-4917-a4e9-cdd0bb8d190f" />

