### PR TITLE
Horseshoe V3: capture current contract and parity fixtures

### DIFF
--- a/ideas/2026.09.05-horseshoe-v3-current-contract.md
+++ b/ideas/2026.09.05-horseshoe-v3-current-contract.md
@@ -1,0 +1,97 @@
+# Horseshoe V3 current contract and parity fixtures
+
+Date: 2026-09-05  
+Parent: [#568](https://github.com/AmoebeLabs/flex-horseshoe-card/issues/568)  
+Subissue: [#569](https://github.com/AmoebeLabs/flex-horseshoe-card/issues/569)
+
+## Purpose
+
+This document freezes the visible behavior of the current horseshoe before the
+generic path engine is introduced. V3 may replace the geometry and rendering
+implementation, but it must preserve these results unless a later issue
+explicitly changes the product contract.
+
+This inventory does not make runtime changes. It identifies the representative
+automated assertions and visual cases that later V3 branches must keep green.
+
+## Configuration boundary
+
+The current horseshoe accepts the established `layout.horseshoes` configuration.
+`layout.horseshoes_v2` and the root-level compatibility fields reach the same
+runtime today, but they are migration inputs rather than three different visual
+contracts. The V3 adapter must normalize configuration once and then feed one
+behavior model.
+
+The minimum useful gauge consists of an entity, position, radius, and scale:
+
+```yaml
+layout:
+  horseshoes:
+    - entity_index: 0
+      xpos: 50
+      ypos: 50
+      radius: 40
+      horseshoe_scale:
+        min: 0
+        max: 100
+```
+
+## Parity matrix
+
+| Area | Current user-visible contract | Representative automated coverage | V3 parity fixture |
+| --- | --- | --- | --- |
+| Arc geometry | `radius`, `tickmarks_radius`, `arc_degrees`, `start_angle`, `rotate`, and `flip` place one gauge around its configured center. A configured 360-degree arc remains visually complete. | Geometry assertions in `tests/horseshoe-shapes.test.js`; normalization assertions in `tests/card-domain-classes.test.js`. | 270-degree gauge plus a complete 360-degree gauge, each with a visible start/end reference. |
+| Scale mapping | `linear`, `spline`, and `splineorg` map values to positions. Values outside the scale remain at its endpoints. | Absolute and spline assertions in `tests/horseshoe-shapes.test.js`. | One linear gauge and one visibly non-linear spline gauge using the same min/current/max values. |
+| Normal state | The state starts at scale minimum and ends at the current value. | Continuous-style assertions in `tests/horseshoe-shapes.test.js`. | Values at minimum, midpoint, maximum, below minimum, and above maximum. |
+| Bidirectional state | `bidirectional`, `bidirectional_symmetrical`, and `bidirectional_linear` start at zero and extend along the matching signed branch. One-sided scales retain the relevant half. | Bidirectional state, tick, and label assertions in `tests/horseshoe-shapes.test.js`. | Negative, zero, and positive values on signed and one-sided scales. |
+| Absolute state | `absolute` draws signed magnitude over the complete arc while retaining the signed value for colors and displayed state. Its active scale, ticks, and labels follow the active sign. | Absolute geometry, colors, gradients, ticks, labels, validation, and spline assertions in `tests/horseshoe-shapes.test.js`. | Matching `-value` and `+value` gauges plus an asymmetric signed scale. |
+| Numeric state styles | `fixed`, `autominmax`, `colorstop`, `colorstopinterpolated`, `colorstopsegments`, `minmaxgradient`, `lineargradient`, and `colorstopgradient` select the current state paint behavior. | Style enumeration and discrete/interpolated color assertions in `tests/horseshoe-shapes.test.js`. | One showcase row with identical geometry and value for every style. |
+| Scale styles | `fixed`, `none`, `colorstopsegments`, `lineargradient`, and `colorstopgradient` control the complete scale independently from the current state. | Segment assertions in `tests/horseshoe-contract.test.js`; gradient path assertions in `tests/horseshoe-shapes.test.js`. | Fixed, hidden, segmented, and gradient scales behind the same state arc. |
+| String states | Ranked string color stops produce numeric geometry while exact Home Assistant states retain their labels, relations, and colors. `stringstate_mode` highlights one segment; `stringstate_level` highlights the range through the active segment. | `tests/string-color-stops.test.js` and string-state paths in `tests/horseshoe-shapes.test.js`. | `low`, `moderate`, `high`, and `very_high` state maps in mode and level variants. |
+| Segments and gaps | Internal gaps are split equally between adjacent ranges. The first and last range keep the true path endpoints. State `segment_gap` overrides the color-stop gap. | Gap override and exact segment-boundary assertions in `tests/horseshoe-shapes.test.js` and `tests/horseshoe-contract.test.js`. | Three strongly contrasting segments with a visible configured gap. |
+| Endpoint caps | Scale and state have independent `linecap.start` and `linecap.end`. Internal segmented endpoints remain butt caps; only the complete visible start/end receive configured caps. | Exact cap assertions in `tests/horseshoe-contract.test.js`. | Mixed round/butt and butt/round endpoints on solid and segmented gauges. |
+| Background layers | Horseshoe, label, and tick backgrounds may be fixed, segmented, or gradient arcs with independent radius, width, gap, and styles. Layer opacity is composed once. | Background construction in `tests/horseshoe-contract.test.js`; opacity composition in `tests/horseshoe-renderer.test.js`. | Visible horseshoe, label, and tick background bands using different widths and opacities. |
+| Major/minor ticks | Major and minor ticks are independently visible, sized, offset, shaped, styled, and colored. Their values use the same active scale branch as the state. | Tick values and positions in `tests/horseshoe-shapes.test.js`. | Major lines plus minor circles on normal, bidirectional, and absolute gauges. |
+| Labels | `none`, `minmax`, `minmax0`, `colorstop`, `ticks_major`, `both`, `segment`, and `stringstate` select label sources. `distance_min` suppresses labels that are too close. Labels can remain horizontal or follow the arc. | Numeric, absolute, and string-state label assertions in `tests/horseshoe-shapes.test.js`; endpoint assertion in `tests/horseshoe-contract.test.js`. | Min/max, major-tick, combined, and string-state label cases in horizontal and arc orientation. |
+| Label backgrounds and badges | A label background is one arc layer. `label_badges` adds one independently styled badge behind every visible label. | Layer opacity in `tests/horseshoe-renderer.test.js`; label-to-badge count in `tests/horseshoe-contract.test.js`. | Same labels shown plain, over a background band, and with individual badges. |
+| Group transforms | Group rotation and scale combine with item rotation and flip around their configured centers. Labels remain readable through inverse item transforms. | Existing geometry methods are part of the frozen contract; add browser screenshot coverage in #570 because SVG text orientation requires a browser. | Rotated and mirrored group containing labels, ticks, scale, and state. |
+| State animation | Numeric state changes interpolate only the displayed state. Disabled animation publishes the target immediately. A new target replaces an active animation without rebuilding static layers. | Direct animator assertions in `tests/horseshoe-contract.test.js`; targeted DOM update behavior remains covered during V3 integration. | Slow linear transition and interrupted transition while labels, ticks, and scale remain stationary. |
+| Layer order | Background bands remain behind scale/state; label and tick backgrounds remain behind their content; state updates do not reorder static layers. | Renderer structure and opacity assertions in `tests/horseshoe-renderer.test.js`. | Semi-transparent overlapping layers that make an ordering regression immediately visible. |
+
+## Markers
+
+The current horseshoe has no standalone path marker configuration or rendered
+marker layer. Labels, badges, and tick shapes must not be reclassified as a
+marker to claim parity. Path markers are therefore a V3 addition, not a current
+horseshoe behavior to migrate. Their contract starts in issue #580 and must use
+measured point, tangent, and normal operations rather than arc-specific math.
+
+## Representative screenshot set
+
+Issue #570 should turn the following cases into deterministic browser fixtures.
+Together they cover the visible contract without creating one screenshot for
+every configuration permutation.
+
+| Fixture | Content | Main regressions detected |
+| --- | --- | --- |
+| `horseshoe-parity-basic` | Fixed scale and state at min, midpoint, and max; 270 and 360 degrees. | Arc endpoints, clamping, width, center, complete circle. |
+| `horseshoe-parity-paint` | All state styles; segmented and gradient scales; mixed caps and gaps. | Colors, range boundaries, seams, cap ownership, gradient direction. |
+| `horseshoe-parity-signed` | Normal, bidirectional variants, and absolute mode with negative/zero/positive values. | Zero placement, direction, active signed branch, tick and label alignment. |
+| `horseshoe-parity-string` | Ranked string mode and level gauges with segment labels. | State ranking, active range, translated label placement and styling. |
+| `horseshoe-parity-annotation` | Major/minor ticks, horizontal/arc labels, label background, badges, transforms. | Offsets, readability, transform composition, layer order. |
+| `horseshoe-parity-animation` | Running and interrupted numeric transitions. | Static-layer flicker, stale paths, wrong final target, rerender regressions. |
+
+## Migration gate
+
+A V3 branch may replace a current horseshoe layer only when:
+
+1. its unit-level assertions remain green;
+2. the corresponding browser parity fixture matches the approved baseline;
+3. the configuration produces the same visible semantics through the temporary
+   `layout.horseshoes_v3` adapter;
+4. no new path generator contains horseshoe-specific value, color, label, tick,
+   badge, or animation decisions.
+
+The final cutover in #584 requires all rows in this matrix. A deliberate product
+change must be documented and reviewed separately rather than hidden inside the
+path-engine migration.

--- a/tests/horseshoe-contract.test.js
+++ b/tests/horseshoe-contract.test.js
@@ -1,0 +1,139 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createValueAnimatorState,
+  startValueAnimation,
+} from '../src/horseshoe-animator.js';
+import { renderLabelBadgesLayer } from '../src/horseshoe-renderer.js';
+import {
+  buildLabelItems,
+  buildScaleArcs,
+} from '../src/horseshoe-shapes.js';
+
+const linearGeometry = {
+  startAngle: 0,
+  endAngle: 180,
+  radius: 40,
+  getActiveSourceRange: () => ({ start: 0, end: 100 }),
+  getActiveColorStops: (colorStops) => colorStops,
+  valueToRatio: (value) => Number(value) / 100,
+  valueToAngle: (value) => Number(value) * 1.8,
+  pointAt: (angle, radius) => ({ x: angle + radius, y: angle - radius }),
+};
+
+test('segmented scale splits internal gaps and preserves configured endpoint caps', () => {
+  const arcs = buildScaleArcs({
+    show: { scale_style: 'colorstopsegments' },
+    horseshoe_scale: {
+      color: '#444444',
+      linecap: { start: 'round', end: 'square' },
+    },
+    colorstops: {
+      gap: 10,
+      colors: [
+        { value: 0, color: '#00ff00' },
+        { value: 50, color: '#ffff00' },
+        { value: 100, color: '#ff0000' },
+      ],
+    },
+  }, linearGeometry);
+
+  assert.deepEqual(arcs.map((arc) => ({
+    startAngle: arc.startAngle,
+    endAngle: arc.endAngle,
+    startCap: arc.startCap,
+    endCap: arc.endCap,
+  })), [
+    { startAngle: 0, endAngle: 85, startCap: 'round', endCap: 'butt' },
+    { startAngle: 95, endAngle: 180, startCap: 'butt', endCap: 'square' },
+  ]);
+});
+
+test('minmax labels retain both scale endpoints and feed one badge per label', () => {
+  const runtimeConfig = {
+    show: {
+      labels_at: 'minmax',
+      label_badges: true,
+    },
+    bar_mode: 'normal',
+    horseshoe_scale: { min: 0, max: 100 },
+    horseshoe_state: { width: 6 },
+    horseshoe_labels: {
+      offset: 8,
+      orientation: 'horizontal',
+      distance_min: 0,
+      badges: { styles: { fill: '#222222' } },
+    },
+    colorstops: { colors: [] },
+  };
+  const labelItems = buildLabelItems(runtimeConfig, linearGeometry);
+  const renderedBadges = renderLabelBadgesLayer(
+    runtimeConfig,
+    { cx: 50, cy: 50 },
+    'contract-card',
+    0,
+    labelItems,
+  );
+
+  assert.deepEqual(labelItems.map((item) => ({ text: item.text, angle: item.angle })), [
+    { text: '0', angle: 0 },
+    { text: '100', angle: 180 },
+  ]);
+  assert.match(renderedBadges.strings.join(''), /horseshoe__label-badges-layer/);
+  assert.equal(renderedBadges.values[1].length, 2);
+});
+
+test('disabled value animation publishes only the final value', () => {
+  const updates = [];
+  const completed = [];
+
+  startValueAnimation(
+    createValueAnimatorState(),
+    { enabled: false, duration: 2500, easing: 'ease-out', debug: false },
+    { fromValue: 10, toValue: 30 },
+    {
+      onUpdate: (value) => updates.push(value),
+      onComplete: (value) => completed.push(value),
+    },
+  );
+
+  assert.deepEqual(updates, [30]);
+  assert.deepEqual(completed, [30]);
+});
+
+test('value animation interpolates display state and completes at the target', (context) => {
+  const frames = [];
+  const updates = [];
+  const completed = [];
+  const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+  const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+
+  globalThis.requestAnimationFrame = (callback) => {
+    frames.push(callback);
+    return frames.length;
+  };
+  globalThis.cancelAnimationFrame = () => {};
+  context.after(() => {
+    globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+  });
+
+  const animatorState = createValueAnimatorState();
+  startValueAnimation(
+    animatorState,
+    { enabled: true, duration: 100, easing: 'linear', debug: false },
+    { fromValue: 10, toValue: 30 },
+    {
+      onUpdate: (value) => updates.push(value),
+      onComplete: (value) => completed.push(value),
+    },
+  );
+
+  frames.shift()(1000);
+  frames.shift()(1050);
+  frames.shift()(1100);
+
+  assert.deepEqual(updates, [10, 20, 30]);
+  assert.deepEqual(completed, [30]);
+  assert.equal(animatorState.animating, false);
+});


### PR DESCRIPTION
## Summary
- freeze the current horseshoe behavior in a parity matrix
- define representative browser screenshot cases for the V3 migration
- add contract tests for segmented gaps and caps, label badges, and value animation

## Scope
- no runtime changes
- no generated distribution changes

## Verification
- npm run build
- 231 tests passed

Parent: #568
Subissue: #569