### PR TITLE
Horseshoe V3: add browser SVG geometry harness

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -1,0 +1,28 @@
+name: Browser geometry tests
+
+on:
+  pull_request:
+    branches:
+      - master
+      - 568-horseshoe-v3-path-engine
+  push:
+    branches:
+      - 568-horseshoe-v3-path-engine
+
+jobs:
+  svg-geometry:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - run: npx playwright install --with-deps chromium
+
+      - run: npm run test:browser

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flex-horseshoe",
-  "version": "5.4.7-dev.22",
+  "version": "5.4.7-dev.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flex-horseshoe",
-      "version": "5.4.7-dev.22",
+      "version": "5.4.7-dev.30",
       "dependencies": {
         "@formatjs/intl-utils": "^3.8.4",
         "@mdi/js": "^7.2.96",
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.8",
+        "@playwright/test": "^1.63.0",
         "@rollup/plugin-alias": "",
         "@rollup/plugin-commonjs": "^29",
         "@rollup/plugin-json": "^6.0.0",
@@ -283,6 +284,22 @@
       "resolved": "https://registry.npmjs.org/@mdi/js/-/js-7.4.47.tgz",
       "integrity": "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@rollup/plugin-alias": {
       "version": "6.0.0",
@@ -1259,6 +1276,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
   "name": "flex-horseshoe",
-  "version": "5.4.7-dev.30",
+  "version": "5.4.7-dev.31",
   "description": "Flexible Horseshoe Card for Lovelace",
   "main": "src/main.js",
   "type": "module",
   "scripts": {
     "build": "npm test && npm run lint && npm run rollup",
     "test": "node --import ./tests/register-loader.js --test tests/*.test.js",
+    "test:browser": "playwright test",
     "rollup": "rollup -c",
-    "lint": "biome lint src/*.js tests/*.js",
+    "lint": "biome lint src/*.js tests/*.js playwright.config.js",
     "format": "biome format --write src/*.js",
     "watch": "rollup -c --watch",
     "postversion": "npm run build",
@@ -17,6 +18,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.8",
+    "@playwright/test": "^1.63.0",
     "@rollup/plugin-alias": "",
     "@rollup/plugin-commonjs": "^29",
     "@rollup/plugin-json": "^6.0.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,17 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.browser.spec.js',
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: 'line',
+  outputDir: '/tmp/fhs-playwright-results',
+  use: {
+    ...devices['Desktop Chrome'],
+    headless: true,
+    viewport: { width: 800, height: 600 },
+  },
+});

--- a/tests/svg-geometry.browser.spec.js
+++ b/tests/svg-geometry.browser.spec.js
@@ -1,0 +1,117 @@
+import { test, expect } from '@playwright/test';
+
+test('SVGGeometryElement reports actual length and points independently from pathLength', async ({ page }) => {
+  await page.setContent(`
+    <svg xmlns="http://www.w3.org/2000/svg" width="240" height="40">
+      <path id="actual" d="M 10 20 L 210 20"></path>
+      <path id="normalized" d="M 10 20 L 210 20" pathLength="100"></path>
+    </svg>
+  `);
+
+  const geometry = await page.evaluate(() => {
+    const actual = document.querySelector('#actual');
+    const normalized = document.querySelector('#normalized');
+    const actualMidpoint = actual.getPointAtLength(actual.getTotalLength() / 2);
+    const normalizedMidpoint = normalized.getPointAtLength(normalized.getTotalLength() / 2);
+
+    return {
+      actualLength: actual.getTotalLength(),
+      normalizedLength: normalized.getTotalLength(),
+      normalizedPathLength: Number(normalized.getAttribute('pathLength')),
+      actualMidpoint: { x: actualMidpoint.x, y: actualMidpoint.y },
+      normalizedMidpoint: { x: normalizedMidpoint.x, y: normalizedMidpoint.y },
+    };
+  });
+
+  expect(geometry.actualLength).toBeCloseTo(200, 5);
+  expect(geometry.normalizedLength).toBeCloseTo(200, 5);
+  expect(geometry.normalizedPathLength).toBe(100);
+  expect(geometry.actualMidpoint).toEqual({ x: 110, y: 20 });
+  expect(geometry.normalizedMidpoint).toEqual({ x: 110, y: 20 });
+});
+
+test('pathLength 100 gives different actual paths the same relative dash coverage', async ({ page }) => {
+  await page.setContent(`
+    <svg xmlns="http://www.w3.org/2000/svg" width="440" height="80">
+      <path id="short" d="M 10 20 L 210 20" pathLength="100"
+        fill="none" stroke="black" stroke-width="10" stroke-dasharray="25 75"></path>
+      <path id="long" d="M 10 60 L 410 60" pathLength="100"
+        fill="none" stroke="black" stroke-width="10" stroke-dasharray="25 75"></path>
+    </svg>
+  `);
+
+  const paintedPoints = await page.evaluate(() => {
+    const shortPath = document.querySelector('#short');
+    const longPath = document.querySelector('#long');
+
+    return {
+      shortInside: shortPath.isPointInStroke(new DOMPoint(50, 20)),
+      shortOutside: shortPath.isPointInStroke(new DOMPoint(90, 20)),
+      longInside: longPath.isPointInStroke(new DOMPoint(90, 60)),
+      longOutside: longPath.isPointInStroke(new DOMPoint(130, 60)),
+    };
+  });
+
+  expect(paintedPoints).toEqual({
+    shortInside: true,
+    shortOutside: false,
+    longInside: true,
+    longOutside: false,
+  });
+});
+
+test('an invisible zero-size master path remains measurable', async ({ page }) => {
+  await page.setContent(`
+    <svg xmlns="http://www.w3.org/2000/svg" width="0" height="0"
+      aria-hidden="true" style="position:absolute;visibility:hidden;pointer-events:none">
+      <path id="measurement" d="M 5 5 C 25 45 75 45 95 5" pathLength="100"></path>
+    </svg>
+  `);
+
+  const measurement = await page.evaluate(() => {
+    const path = document.querySelector('#measurement');
+    const length = path.getTotalLength();
+    const midpoint = path.getPointAtLength(length / 2);
+
+    return {
+      connected: path.isConnected,
+      length,
+      midpoint: { x: midpoint.x, y: midpoint.y },
+    };
+  });
+
+  expect(measurement.connected).toBe(true);
+  expect(measurement.length).toBeGreaterThan(90);
+  expect(measurement.midpoint.x).toBeCloseTo(50, 3);
+  expect(measurement.midpoint.y).toBeGreaterThan(30);
+});
+
+test('geometry-dependent content stays hidden until its first path binding is complete', async ({ page }) => {
+  await page.setContent(`
+    <svg xmlns="http://www.w3.org/2000/svg" width="240" height="80">
+      <path id="measurement" d="M 10 40 L 210 40" pathLength="100"
+        fill="none" stroke="transparent"></path>
+      <circle id="dependent" cx="0" cy="0" r="5" visibility="hidden"></circle>
+    </svg>
+    <script>
+      window.bindPathGeometry = () => new Promise((resolve) => {
+        requestAnimationFrame(() => {
+          const path = document.querySelector('#measurement');
+          const dependent = document.querySelector('#dependent');
+          const point = path.getPointAtLength(path.getTotalLength() / 2);
+
+          dependent.setAttribute('cx', point.x);
+          dependent.setAttribute('cy', point.y);
+          dependent.setAttribute('visibility', 'visible');
+          resolve();
+        });
+      });
+    </script>
+  `);
+
+  await expect(page.locator('#dependent')).toHaveAttribute('visibility', 'hidden');
+  await page.evaluate(() => window.bindPathGeometry());
+  await expect(page.locator('#dependent')).toHaveAttribute('visibility', 'visible');
+  await expect(page.locator('#dependent')).toHaveAttribute('cx', '110');
+  await expect(page.locator('#dependent')).toHaveAttribute('cy', '40');
+});


### PR DESCRIPTION
## Summary
- add a Chromium-based Playwright harness for native SVG path geometry
- verify pathLength normalization and hidden measurement paths
- verify geometry-dependent content stays hidden through its initial binding
- run browser geometry tests for the V3 feature branch in GitHub Actions

## Verification
- npm run build
- npm run test:browser

Parent: #568
Closes #570