### PR TITLE
Horseshoe V3: add initial path centerline generators

### DIFF
--- a/src/path-generators.js
+++ b/src/path-generators.js
@@ -1,0 +1,161 @@
+/**
+ * Creates the shared stable definition consumed by browser geometry. The
+ * generated path itself is the cache identity, so equivalent geometry reuses
+ * one measurement regardless of which configuration produced it.
+ *
+ * @param {string} d - SVG centerline path data.
+ * @param {boolean} closed - Whether the centerline returns to its start.
+ * @returns {object} Stable path definition.
+ */
+function createPathDefinition(d, closed) {
+  const definition = {
+    d,
+    closed,
+    direction: 'forward',
+  };
+
+  return {
+    ...definition,
+    signature: JSON.stringify(definition),
+  };
+}
+
+/**
+ * Builds a circular or elliptical centerline from a start angle and signed
+ * sweep. A complete ring uses two arcs because one SVG arc cannot return to its
+ * own start point.
+ *
+ * @param {object} config - Normalized arc geometry.
+ * @returns {object} Stable arc path definition.
+ */
+export function buildArcPathDefinition(config) {
+  const startRadians = (config.startAngle * Math.PI) / 180;
+  const endAngle = config.startAngle + config.arcDegrees;
+  const endRadians = (endAngle * Math.PI) / 180;
+  const startX = config.cx + config.radiusX * Math.cos(startRadians);
+  const startY = config.cy + config.radiusY * Math.sin(startRadians);
+  const endX = config.cx + config.radiusX * Math.cos(endRadians);
+  const endY = config.cy + config.radiusY * Math.sin(endRadians);
+  const sweepFlag = config.arcDegrees >= 0 ? 1 : 0;
+
+  if (Math.abs(config.arcDegrees) === 360) {
+    const middleRadians = ((config.startAngle + config.arcDegrees / 2) * Math.PI) / 180;
+    const middleX = config.cx + config.radiusX * Math.cos(middleRadians);
+    const middleY = config.cy + config.radiusY * Math.sin(middleRadians);
+    const d = `M ${startX} ${startY} A ${config.radiusX} ${config.radiusY} 0 1 ${sweepFlag} ${middleX} ${middleY} A ${config.radiusX} ${config.radiusY} 0 1 ${sweepFlag} ${endX} ${endY} Z`;
+
+    return createPathDefinition(d, true);
+  }
+
+  const largeArcFlag = Math.abs(config.arcDegrees) > 180 ? 1 : 0;
+  const d = `M ${startX} ${startY} A ${config.radiusX} ${config.radiusY} 0 ${largeArcFlag} ${sweepFlag} ${endX} ${endY}`;
+
+  return createPathDefinition(d, false);
+}
+
+/**
+ * Builds a straight centerline between two configured points.
+ *
+ * @param {object} config - Normalized line geometry.
+ * @returns {object} Stable line path definition.
+ */
+export function buildLinePathDefinition(config) {
+  return createPathDefinition(`M ${config.x1} ${config.y1} L ${config.x2} ${config.y2}`, false);
+}
+
+/**
+ * Builds a closed rectangular centerline with independent corner radii. The
+ * start side changes only the path origin; direction controls traversal order.
+ *
+ * @param {object} config - Normalized rectangle geometry.
+ * @returns {object} Stable rectangle path definition.
+ */
+export function buildRectanglePathDefinition(config) {
+  const left = config.x;
+  const top = config.y;
+  const right = config.x + config.width;
+  const bottom = config.y + config.height;
+  const centerX = config.x + config.width / 2;
+  const centerY = config.y + config.height / 2;
+  const startPoints = {
+    top: `${centerX} ${top}`,
+    right: `${right} ${centerY}`,
+    bottom: `${centerX} ${bottom}`,
+    left: `${left} ${centerY}`,
+  };
+  const sideOrder = ['top', 'right', 'bottom', 'left'];
+  const clockwiseSections = {
+    top: `L ${right - config.radiusTopRight} ${top} Q ${right} ${top} ${right} ${top + config.radiusTopRight} L ${right} ${centerY}`,
+    right: `L ${right} ${bottom - config.radiusBottomRight} Q ${right} ${bottom} ${right - config.radiusBottomRight} ${bottom} L ${centerX} ${bottom}`,
+    bottom: `L ${left + config.radiusBottomLeft} ${bottom} Q ${left} ${bottom} ${left} ${bottom - config.radiusBottomLeft} L ${left} ${centerY}`,
+    left: `L ${left} ${top + config.radiusTopLeft} Q ${left} ${top} ${left + config.radiusTopLeft} ${top} L ${centerX} ${top}`,
+  };
+  const counterClockwiseSections = {
+    top: `L ${left + config.radiusTopLeft} ${top} Q ${left} ${top} ${left} ${top + config.radiusTopLeft} L ${left} ${centerY}`,
+    left: `L ${left} ${bottom - config.radiusBottomLeft} Q ${left} ${bottom} ${left + config.radiusBottomLeft} ${bottom} L ${centerX} ${bottom}`,
+    bottom: `L ${right - config.radiusBottomRight} ${bottom} Q ${right} ${bottom} ${right} ${bottom - config.radiusBottomRight} L ${right} ${centerY}`,
+    right: `L ${right} ${top + config.radiusTopRight} Q ${right} ${top} ${right - config.radiusTopRight} ${top} L ${centerX} ${top}`,
+  };
+  const startIndex = sideOrder.indexOf(config.start);
+  const orderedSides = config.direction === 'clockwise'
+    ? [...sideOrder.slice(startIndex), ...sideOrder.slice(0, startIndex)]
+    : [...sideOrder.slice(0, startIndex + 1).reverse(), ...sideOrder.slice(startIndex + 1).reverse()];
+  const sections = config.direction === 'clockwise' ? clockwiseSections : counterClockwiseSections;
+  const d = `M ${startPoints[config.start]} ${orderedSides.map((side) => sections[side]).join(' ')} Z`;
+
+  return createPathDefinition(d, true);
+}
+
+/**
+ * Builds a smooth wave between two points. Every configured wave consists of
+ * two cubic half-waves; matching control vectors keep the joins tangent-continuous.
+ *
+ * @param {object} config - Normalized wave geometry.
+ * @returns {object} Stable wave path definition.
+ */
+export function buildWavePathDefinition(config) {
+  const deltaX = config.x2 - config.x1;
+  const deltaY = config.y2 - config.y1;
+  const baselineLength = Math.hypot(deltaX, deltaY);
+  const normalX = -deltaY / baselineLength;
+  const normalY = deltaX / baselineLength;
+  const halfWaveCount = config.waves * 2;
+  const commands = [`M ${config.x1} ${config.y1}`];
+
+  for (let index = 0; index < halfWaveCount; index += 1) {
+    const startProgress = index / halfWaveCount;
+    const endProgress = (index + 1) / halfWaveCount;
+    const controlOneProgress = startProgress + (endProgress - startProgress) / 3;
+    const controlTwoProgress = startProgress + ((endProgress - startProgress) * 2) / 3;
+    const signedControlAmplitude = (index % 2 === 0 ? config.amplitude : -config.amplitude) * (4 / 3);
+    const controlOneX = config.x1 + deltaX * controlOneProgress + normalX * signedControlAmplitude;
+    const controlOneY = config.y1 + deltaY * controlOneProgress + normalY * signedControlAmplitude;
+    const controlTwoX = config.x1 + deltaX * controlTwoProgress + normalX * signedControlAmplitude;
+    const controlTwoY = config.y1 + deltaY * controlTwoProgress + normalY * signedControlAmplitude;
+    const endX = config.x1 + deltaX * endProgress;
+    const endY = config.y1 + deltaY * endProgress;
+
+    commands.push(`C ${controlOneX} ${controlOneY} ${controlTwoX} ${controlTwoY} ${endX} ${endY}`);
+  }
+
+  return createPathDefinition(commands.join(' '), false);
+}
+
+/**
+ * Dispatches normalized shape configuration to its centerline generator.
+ *
+ * @param {object} config - Normalized path geometry with a supported type.
+ * @returns {object} Stable path definition.
+ */
+export function buildPathDefinition(config) {
+  switch (config.type) {
+    case 'arc':
+      return buildArcPathDefinition(config);
+    case 'line':
+      return buildLinePathDefinition(config);
+    case 'rectangle':
+      return buildRectanglePathDefinition(config);
+    case 'wave':
+      return buildWavePathDefinition(config);
+  }
+}

--- a/tests/path-generators.test.js
+++ b/tests/path-generators.test.js
@@ -1,0 +1,140 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildArcPathDefinition,
+  buildLinePathDefinition,
+  buildPathDefinition,
+  buildRectanglePathDefinition,
+  buildWavePathDefinition,
+} from '../src/path-generators.js';
+
+test('arc generator builds partial clockwise and counter-clockwise centerlines', () => {
+  const clockwise = buildArcPathDefinition({
+    cx: 50,
+    cy: 50,
+    radiusX: 40,
+    radiusY: 30,
+    startAngle: 0,
+    arcDegrees: 270,
+  });
+  const counterClockwise = buildArcPathDefinition({
+    cx: 50,
+    cy: 50,
+    radiusX: 40,
+    radiusY: 30,
+    startAngle: 0,
+    arcDegrees: -90,
+  });
+
+  assert.equal(clockwise.closed, false);
+  assert.equal(clockwise.direction, 'forward');
+  assert.match(clockwise.d, /^M 90 50 A 40 30 0 1 1 /);
+  assert.match(counterClockwise.d, /^M 90 50 A 40 30 0 0 0 /);
+  assert.notEqual(clockwise.signature, counterClockwise.signature);
+});
+
+test('arc generator splits a complete ring into two centerline arcs', () => {
+  const definition = buildArcPathDefinition({
+    cx: 50,
+    cy: 50,
+    radiusX: 40,
+    radiusY: 40,
+    startAngle: -90,
+    arcDegrees: 360,
+  });
+
+  assert.equal(definition.closed, true);
+  assert.equal((definition.d.match(/ A /g) ?? []).length, 2);
+  assert.match(definition.d, / Z$/);
+});
+
+test('line generator preserves configured endpoints', () => {
+  const definition = buildLinePathDefinition({
+    x1: 10,
+    y1: 20,
+    x2: 90,
+    y2: 80,
+  });
+
+  assert.deepEqual(definition, {
+    d: 'M 10 20 L 90 80',
+    closed: false,
+    direction: 'forward',
+    signature: JSON.stringify({
+      d: 'M 10 20 L 90 80',
+      closed: false,
+      direction: 'forward',
+    }),
+  });
+});
+
+test('rectangle generator keeps one signature for equivalent geometry', () => {
+  const config = {
+    type: 'rectangle',
+    x: 10,
+    y: 20,
+    width: 80,
+    height: 60,
+    radiusTopLeft: 5,
+    radiusTopRight: 10,
+    radiusBottomRight: 15,
+    radiusBottomLeft: 20,
+    start: 'top',
+    direction: 'clockwise',
+  };
+  const direct = buildRectanglePathDefinition(config);
+  const dispatched = buildPathDefinition(config);
+
+  assert.equal(direct.closed, true);
+  assert.equal(direct.d, 'M 50 20 L 80 20 Q 90 20 90 30 L 90 50 L 90 65 Q 90 80 75 80 L 50 80 L 30 80 Q 10 80 10 60 L 10 50 L 10 25 Q 10 20 15 20 L 50 20 Z');
+  assert.equal(dispatched.signature, direct.signature);
+});
+
+test('rectangle generator changes origin and traversal without changing its bounds', () => {
+  const definition = buildRectanglePathDefinition({
+    x: 10,
+    y: 20,
+    width: 80,
+    height: 60,
+    radiusTopLeft: 0,
+    radiusTopRight: 0,
+    radiusBottomRight: 0,
+    radiusBottomLeft: 0,
+    start: 'right',
+    direction: 'counter-clockwise',
+  });
+
+  assert.match(definition.d, /^M 90 50 L 90 20/);
+  assert.match(definition.d, /L 90 50 Z$/);
+});
+
+test('wave generator preserves endpoints and emits two cubic halves per wave', () => {
+  const definition = buildWavePathDefinition({
+    x1: 10,
+    y1: 50,
+    x2: 130,
+    y2: 50,
+    waves: 3,
+    amplitude: 12,
+  });
+
+  assert.equal(definition.closed, false);
+  assert.match(definition.d, /^M 10 50 /);
+  assert.equal((definition.d.match(/ C /g) ?? []).length, 6);
+  assert.match(definition.d, /130 50$/);
+});
+
+test('wave generator applies amplitude perpendicular to a vertical baseline', () => {
+  const definition = buildWavePathDefinition({
+    x1: 50,
+    y1: 10,
+    x2: 50,
+    y2: 90,
+    waves: 1,
+    amplitude: 9,
+  });
+
+  assert.match(definition.d, /^M 50 10 C 38 /);
+  assert.match(definition.d, /50 90$/);
+});

--- a/tests/svg-geometry.browser.spec.js
+++ b/tests/svg-geometry.browser.spec.js
@@ -233,3 +233,96 @@ test('PathGeometry measures each signature once and hides output during rebindin
     },
   });
 });
+
+test('all initial path generators produce measurable centerlines with stable endpoints', async ({ page }) => {
+  const pathGeneratorSource = await readFile(new URL('../src/path-generators.js', import.meta.url), 'utf8');
+
+  const generatedPaths = await page.evaluate(async (moduleSource) => {
+    const moduleUrl = URL.createObjectURL(new Blob([moduleSource], { type: 'text/javascript' }));
+    const { buildPathDefinition } = await import(moduleUrl);
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    const configs = [
+      {
+        type: 'arc',
+        cx: 50,
+        cy: 50,
+        radiusX: 40,
+        radiusY: 40,
+        startAngle: 0,
+        arcDegrees: 90,
+      },
+      {
+        type: 'line',
+        x1: 10,
+        y1: 20,
+        x2: 110,
+        y2: 70,
+      },
+      {
+        type: 'rectangle',
+        x: 10,
+        y: 20,
+        width: 100,
+        height: 60,
+        radiusTopLeft: 5,
+        radiusTopRight: 10,
+        radiusBottomRight: 15,
+        radiusBottomLeft: 20,
+        start: 'right',
+        direction: 'counter-clockwise',
+      },
+      {
+        type: 'wave',
+        x1: 10,
+        y1: 50,
+        x2: 130,
+        y2: 50,
+        waves: 3,
+        amplitude: 12,
+      },
+    ];
+    const measurements = configs.map((config) => {
+      const definition = buildPathDefinition(config);
+      const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+      path.setAttribute('d', definition.d);
+      svg.append(path);
+      const length = path.getTotalLength();
+      const start = path.getPointAtLength(0);
+      const end = path.getPointAtLength(length);
+
+      return {
+        type: config.type,
+        closed: definition.closed,
+        length,
+        start: { x: start.x, y: start.y },
+        end: { x: end.x, y: end.y },
+      };
+    });
+
+    document.body.append(svg);
+    URL.revokeObjectURL(moduleUrl);
+    return measurements;
+  }, pathGeneratorSource);
+
+  const [arc, line, rectangle, wave] = generatedPaths;
+
+  expect(arc.length).toBeCloseTo(Math.PI * 20, 1);
+  expect(arc.start.x).toBeCloseTo(90, 4);
+  expect(arc.start.y).toBeCloseTo(50, 4);
+  expect(arc.end.x).toBeCloseTo(50, 4);
+  expect(arc.end.y).toBeCloseTo(90, 4);
+
+  expect(line.length).toBeCloseTo(Math.hypot(100, 50), 4);
+  expect(line.start).toEqual({ x: 10, y: 20 });
+  expect(line.end).toEqual({ x: 110, y: 70 });
+
+  expect(rectangle.closed).toBe(true);
+  expect(rectangle.length).toBeGreaterThan(280);
+  expect(rectangle.start.x).toBeCloseTo(rectangle.end.x, 4);
+  expect(rectangle.start.y).toBeCloseTo(rectangle.end.y, 4);
+
+  expect(wave.length).toBeGreaterThan(120);
+  expect(wave.start).toEqual({ x: 10, y: 50 });
+  expect(wave.end.x).toBeCloseTo(130, 4);
+  expect(wave.end.y).toBeCloseTo(50, 4);
+});


### PR DESCRIPTION
## Summary
- add shared centerline generators for arc, line, rectangle, and wave
- retain SAK proven arc and line principles without its tool lifecycle
- support complete rings, rectangle start side and direction, and tangent-continuous waves
- verify every generated path with unit contracts and real Chromium geometry

## Verification
- npm run build
- npm run test:browser

Parent: #568
Closes #572