### PR TITLE
Horseshoe V3: implement shared measured geometry contract

### DIFF
--- a/src/path-geometry.js
+++ b/src/path-geometry.js
@@ -58,6 +58,8 @@ export default class PathGeometry {
     if (!this.activeMeasurement) {
       this.activeMeasurement = {
         totalLength: pathElement.getTotalLength(),
+        points: new Map(),
+        tangents: new Map(),
       };
       this.measurementCache.set(this.pathDefinition.signature, this.activeMeasurement);
     }
@@ -102,5 +104,107 @@ export default class PathGeometry {
    */
   getPathElement() {
     return this.pathElement;
+  }
+
+  /**
+   * Returns a browser-measured coordinate at normalized path progress. The
+   * normalized-to-actual conversion remains private to this geometry boundary.
+   *
+   * @param {number} progress - Position in normalized 0..100 path space.
+   * @returns {object} Point with x and y coordinates in SVG user units.
+   */
+  pointAtProgress(progress) {
+    if (!this.activeMeasurement.points.has(progress)) {
+      const actualDistance = (progress / 100) * this.activeMeasurement.totalLength;
+      const measuredPoint = this.pathElement.getPointAtLength(actualDistance);
+
+      this.activeMeasurement.points.set(progress, {
+        x: measuredPoint.x,
+        y: measuredPoint.y,
+      });
+    }
+
+    return this.activeMeasurement.points.get(progress);
+  }
+
+  /**
+   * Returns the unit direction of path traversal at normalized progress. Open
+   * endpoints use a one-sided sample, ordinary positions and corners use a
+   * centered sample, and a closed seam samples across the end/start boundary.
+   * An exact cusp follows its outgoing branch.
+   *
+   * @param {number} progress - Position in normalized 0..100 path space.
+   * @returns {object} Unit tangent with x and y vector components.
+   */
+  tangentAtProgress(progress) {
+    if (!this.activeMeasurement.tangents.has(progress)) {
+      const totalLength = this.activeMeasurement.totalLength;
+      const actualDistance = (progress / 100) * totalLength;
+      const sampleDistance = Math.min(0.01, totalLength / 2);
+      let beforeDistance;
+      let afterDistance;
+
+      if (this.pathDefinition.closed) {
+        beforeDistance = (actualDistance - sampleDistance + totalLength) % totalLength;
+        afterDistance = (actualDistance + sampleDistance) % totalLength;
+      } else {
+        beforeDistance = Math.max(0, actualDistance - sampleDistance);
+        afterDistance = Math.min(totalLength, actualDistance + sampleDistance);
+      }
+
+      const before = this.pathElement.getPointAtLength(beforeDistance);
+      const after = this.pathElement.getPointAtLength(afterDistance);
+      let deltaX = after.x - before.x;
+      let deltaY = after.y - before.y;
+      let vectorLength = Math.hypot(deltaX, deltaY);
+      const cuspThreshold = sampleDistance / 100;
+
+      // Symmetrical samples coincide at an exact cusp. Select the outgoing
+      // branch first, then the incoming branch at an open path endpoint.
+      if (vectorLength < cuspThreshold) {
+        const cusp = this.pathElement.getPointAtLength(actualDistance);
+        const outgoingDistance = this.pathDefinition.closed
+          ? (actualDistance + sampleDistance) % totalLength
+          : Math.min(totalLength, actualDistance + sampleDistance);
+        const outgoing = this.pathElement.getPointAtLength(outgoingDistance);
+        deltaX = outgoing.x - cusp.x;
+        deltaY = outgoing.y - cusp.y;
+        vectorLength = Math.hypot(deltaX, deltaY);
+
+        if (vectorLength < cuspThreshold) {
+          const incomingDistance = this.pathDefinition.closed
+            ? (actualDistance - sampleDistance + totalLength) % totalLength
+            : Math.max(0, actualDistance - sampleDistance);
+          const incoming = this.pathElement.getPointAtLength(incomingDistance);
+          deltaX = cusp.x - incoming.x;
+          deltaY = cusp.y - incoming.y;
+          vectorLength = Math.hypot(deltaX, deltaY);
+        }
+      }
+
+      this.activeMeasurement.tangents.set(progress, {
+        x: deltaX / vectorLength,
+        y: deltaY / vectorLength,
+      });
+    }
+
+    return this.activeMeasurement.tangents.get(progress);
+  }
+
+  /**
+   * Returns the unit normal on the requested visual side relative to path
+   * traversal. SVG's downward y-axis is accounted for, and both sides are exact
+   * opposites.
+   *
+   * @param {number} progress - Position in normalized 0..100 path space.
+   * @param {'left'|'right'} side - Side relative to forward path traversal.
+   * @returns {object} Unit normal with x and y vector components.
+   */
+  normalAtProgress(progress, side) {
+    const tangent = this.tangentAtProgress(progress);
+
+    return side === 'left'
+      ? { x: tangent.y, y: -tangent.x }
+      : { x: -tangent.y, y: tangent.x };
   }
 }

--- a/tests/path-geometry.test.js
+++ b/tests/path-geometry.test.js
@@ -21,6 +21,23 @@ function createMeasuredPath(totalLength) {
   return { pathElement, measurement };
 }
 
+/**
+ * Creates a straight horizontal SVG geometry stand-in for point contracts.
+ *
+ * @param {number} totalLength - Length and end coordinate of the path.
+ * @returns {object} Path element stand-in.
+ */
+function createHorizontalPath(totalLength) {
+  return {
+    getTotalLength() {
+      return totalLength;
+    },
+    getPointAtLength(distance) {
+      return { x: distance, y: 20 };
+    },
+  };
+}
+
 test('binds an active path before geometry-dependent output becomes ready', () => {
   let requestedRenders = 0;
   const geometry = new PathGeometry(() => {
@@ -137,4 +154,42 @@ test('reuses cached browser measurements when a prior signature becomes active a
   assert.equal(secondPath.measurement.calls, 1);
   assert.equal(reboundFirstPath.measurement.calls, 0);
   assert.equal(requestedRenders, 3);
+});
+
+test('converts normalized progress to actual browser distance inside PathGeometry', () => {
+  const geometry = new PathGeometry(() => {});
+  const definition = {
+    d: 'M 0 20 L 200 20',
+    closed: false,
+    direction: 'forward',
+    signature: 'line-200',
+  };
+
+  geometry.setPathDefinition(definition);
+  geometry.bindPathElement(createHorizontalPath(200));
+
+  assert.deepEqual(geometry.pointAtProgress(0), { x: 0, y: 20 });
+  assert.deepEqual(geometry.pointAtProgress(25), { x: 50, y: 20 });
+  assert.deepEqual(geometry.pointAtProgress(50), { x: 100, y: 20 });
+  assert.deepEqual(geometry.pointAtProgress(75), { x: 150, y: 20 });
+  assert.deepEqual(geometry.pointAtProgress(100), { x: 200, y: 20 });
+});
+
+test('returns normalized tangent and opposing left/right normals', () => {
+  const geometry = new PathGeometry(() => {});
+  const definition = {
+    d: 'M 0 20 L 200 20',
+    closed: false,
+    direction: 'forward',
+    signature: 'line-200',
+  };
+
+  geometry.setPathDefinition(definition);
+  geometry.bindPathElement(createHorizontalPath(200));
+
+  assert.deepEqual(geometry.tangentAtProgress(0), { x: 1, y: 0 });
+  assert.deepEqual(geometry.tangentAtProgress(50), { x: 1, y: 0 });
+  assert.deepEqual(geometry.tangentAtProgress(100), { x: 1, y: 0 });
+  assert.deepEqual(geometry.normalAtProgress(50, 'left'), { x: 0, y: -1 });
+  assert.deepEqual(geometry.normalAtProgress(50, 'right'), { x: -0, y: 1 });
 });

--- a/tests/svg-geometry.browser.spec.js
+++ b/tests/svg-geometry.browser.spec.js
@@ -326,3 +326,155 @@ test('all initial path generators produce measurable centerlines with stable end
   expect(wave.end.x).toBeCloseTo(130, 4);
   expect(wave.end.y).toBeCloseTo(50, 4);
 });
+
+test('shared measured geometry handles every initial shape, boundaries, corners, cusps, and seams', async ({ page }) => {
+  const pathGeometrySource = await readFile(new URL('../src/path-geometry.js', import.meta.url), 'utf8');
+  const pathGeneratorSource = await readFile(new URL('../src/path-generators.js', import.meta.url), 'utf8');
+
+  const geometryContracts = await page.evaluate(async ({ geometrySource, generatorSource }) => {
+    const geometryModuleUrl = URL.createObjectURL(new Blob([geometrySource], { type: 'text/javascript' }));
+    const generatorModuleUrl = URL.createObjectURL(new Blob([generatorSource], { type: 'text/javascript' }));
+    const { default: PathGeometry } = await import(geometryModuleUrl);
+    const { buildPathDefinition } = await import(generatorModuleUrl);
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    document.body.append(svg);
+
+    const configs = [
+      {
+        type: 'arc',
+        cx: 50,
+        cy: 50,
+        radiusX: 40,
+        radiusY: 40,
+        startAngle: 0,
+        arcDegrees: 270,
+      },
+      {
+        type: 'line',
+        x1: 10,
+        y1: 20,
+        x2: 110,
+        y2: 70,
+      },
+      {
+        type: 'rectangle',
+        x: 10,
+        y: 20,
+        width: 100,
+        height: 60,
+        radiusTopLeft: 0,
+        radiusTopRight: 0,
+        radiusBottomRight: 0,
+        radiusBottomLeft: 0,
+        start: 'top',
+        direction: 'clockwise',
+      },
+      {
+        type: 'wave',
+        x1: 10,
+        y1: 50,
+        x2: 130,
+        y2: 50,
+        waves: 3,
+        amplitude: 12,
+      },
+    ];
+    const sharedContracts = configs.map((config) => {
+      const definition = buildPathDefinition(config);
+      const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+      path.setAttribute('d', definition.d);
+      svg.append(path);
+      const geometry = new PathGeometry(() => {});
+      geometry.setPathDefinition(definition);
+      geometry.bindPathElement(path);
+
+      return {
+        type: config.type,
+        samples: [0, 25, 50, 75, 100].map((progress) => ({
+          point: geometry.pointAtProgress(progress),
+          tangent: geometry.tangentAtProgress(progress),
+          left: geometry.normalAtProgress(progress, 'left'),
+          right: geometry.normalAtProgress(progress, 'right'),
+        })),
+      };
+    });
+
+    const clockwiseArc = sharedContracts[0].samples[0].tangent;
+    const counterClockwiseDefinition = buildPathDefinition({
+      type: 'arc',
+      cx: 50,
+      cy: 50,
+      radiusX: 40,
+      radiusY: 40,
+      startAngle: 0,
+      arcDegrees: -90,
+    });
+    const counterClockwisePath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    counterClockwisePath.setAttribute('d', counterClockwiseDefinition.d);
+    svg.append(counterClockwisePath);
+    const counterClockwiseGeometry = new PathGeometry(() => {});
+    counterClockwiseGeometry.setPathDefinition(counterClockwiseDefinition);
+    counterClockwiseGeometry.bindPathElement(counterClockwisePath);
+
+    const rectangleDefinition = buildPathDefinition(configs[2]);
+    const rectanglePath = svg.querySelectorAll('path')[2];
+    const rectangleGeometry = new PathGeometry(() => {});
+    rectangleGeometry.setPathDefinition(rectangleDefinition);
+    rectangleGeometry.bindPathElement(rectanglePath);
+    const cornerTangent = rectangleGeometry.tangentAtProgress((50 / rectangleGeometry.getTotalLength()) * 100);
+    const seamStart = rectangleGeometry.tangentAtProgress(0);
+    const seamEnd = rectangleGeometry.tangentAtProgress(100);
+
+    const cuspDefinition = {
+      d: 'M 0 0 L 50 0 L 0 0',
+      closed: false,
+      direction: 'forward',
+      signature: 'cusp',
+    };
+    const cuspPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    cuspPath.setAttribute('d', cuspDefinition.d);
+    svg.append(cuspPath);
+    const cuspGeometry = new PathGeometry(() => {});
+    cuspGeometry.setPathDefinition(cuspDefinition);
+    cuspGeometry.bindPathElement(cuspPath);
+    const cuspTangent = cuspGeometry.tangentAtProgress(50);
+
+    URL.revokeObjectURL(geometryModuleUrl);
+    URL.revokeObjectURL(generatorModuleUrl);
+    return {
+      sharedContracts,
+      clockwiseArc,
+      counterClockwiseArc: counterClockwiseGeometry.tangentAtProgress(0),
+      cornerTangent,
+      seamStart,
+      seamEnd,
+      cuspTangent,
+    };
+  }, {
+    geometrySource: pathGeometrySource,
+    generatorSource: pathGeneratorSource,
+  });
+
+  geometryContracts.sharedContracts.forEach(({ samples }) => {
+    samples.forEach(({ point, tangent, left, right }) => {
+      [point.x, point.y, tangent.x, tangent.y, left.x, left.y, right.x, right.y].forEach((value) => {
+        expect(Number.isFinite(value)).toBe(true);
+      });
+      expect(Math.hypot(tangent.x, tangent.y)).toBeCloseTo(1, 5);
+      expect(tangent.x * left.x + tangent.y * left.y).toBeCloseTo(0, 5);
+      expect(left.x).toBeCloseTo(-right.x, 5);
+      expect(left.y).toBeCloseTo(-right.y, 5);
+    });
+  });
+
+  expect(geometryContracts.clockwiseArc.x).toBeCloseTo(0, 2);
+  expect(geometryContracts.clockwiseArc.y).toBeCloseTo(1, 3);
+  expect(geometryContracts.counterClockwiseArc.x).toBeCloseTo(0, 2);
+  expect(geometryContracts.counterClockwiseArc.y).toBeCloseTo(-1, 3);
+  expect(geometryContracts.cornerTangent.x).toBeCloseTo(Math.SQRT1_2, 2);
+  expect(geometryContracts.cornerTangent.y).toBeCloseTo(Math.SQRT1_2, 2);
+  expect(geometryContracts.seamStart.x).toBeCloseTo(geometryContracts.seamEnd.x, 5);
+  expect(geometryContracts.seamStart.y).toBeCloseTo(geometryContracts.seamEnd.y, 5);
+  expect(geometryContracts.cuspTangent.x).toBeCloseTo(-1, 5);
+  expect(geometryContracts.cuspTangent.y).toBeCloseTo(0, 3);
+});


### PR DESCRIPTION
## Summary
- extend PathGeometry with normalized point, tangent, and visual left/right normal queries
- cache browser samples per geometry signature
- define one-sided endpoints, centered corners, outgoing cusps, and wrapped closed seams
- verify arc, line, rectangle, and wave through one real-browser geometry contract

## Verification
- npm run build
- npm run test:browser

Parent: #568
Closes #573