### PR TITLE
Horseshoe V3: implement generic stroke and dash renderer

### DIFF
--- a/src/path-renderer.js
+++ b/src/path-renderer.js
@@ -1,0 +1,71 @@
+import { svg } from 'lit';
+
+/**
+ * Renders one path centerline as a background track and normalized painted
+ * ranges. Every visible layer reuses the same complete path definition;
+ * pathLength="100" makes range placement independent from actual path length.
+ *
+ * @param {object} pathDefinition - Stable generated centerline definition.
+ * @param {object} background - Normalized background stroke configuration.
+ * @param {Array<object>} paintedRanges - Normalized ranges from buildPaintedRanges().
+ * @param {string} pathId - Stable DOM namespace for this rendered path.
+ * @returns {TemplateResult} Generic SVG path layers.
+ */
+export function renderPathStrokeLayers(pathDefinition, background, paintedRanges, pathId) {
+  return svg`
+    <g class="path-stroke-renderer" data-path-signature=${pathDefinition.signature}>
+      <path
+        id="${pathId}-master"
+        class="path-stroke-renderer__master"
+        data-path-master=${pathId}
+        d=${pathDefinition.d}
+        pathLength="100"
+        fill="none"
+        stroke="transparent"
+        stroke-width="0"
+        visibility="hidden"
+        pointer-events="none"
+      ></path>
+
+      <path
+        id="${pathId}-background"
+        class="path-stroke-renderer__background"
+        d=${pathDefinition.d}
+        pathLength="100"
+        fill="none"
+        stroke=${background.color}
+        stroke-width=${background.width}
+        stroke-opacity=${background.opacity}
+        stroke-linecap=${background.linecap}
+        pointer-events="none"
+      ></path>
+
+      <g class="path-stroke-renderer__ranges" pointer-events="none">
+        ${paintedRanges.map((range) => {
+          // Mixed endpoint caps require the mask layer added in #577. Until
+          // then, a mixed range stays geometrically exact with butt endpoints.
+          const linecap = range.startCap === range.endCap ? range.startCap : 'butt';
+
+          return svg`
+            <path
+              id="${pathId}-range-${range.id}"
+              class="path-stroke-renderer__range"
+              data-path-range=${range.id}
+              d=${pathDefinition.d}
+              pathLength="100"
+              fill="none"
+              stroke=${range.color}
+              stroke-width=${range.width}
+              stroke-opacity=${range.opacity}
+              stroke-linecap=${linecap}
+              stroke-dasharray=${range.dash.array.join(' ')}
+              stroke-dashoffset=${range.dash.offset}
+            ></path>
+          `;
+        })}
+      </g>
+    </g>
+  `;
+}
+
+export default renderPathStrokeLayers;

--- a/tests/path-renderer.browser.spec.js
+++ b/tests/path-renderer.browser.spec.js
@@ -1,0 +1,120 @@
+import { readFile } from 'node:fs/promises';
+
+import { expect, test } from '@playwright/test';
+
+test('generic renderer paints the same normalized ranges on every path shape', async ({ page }) => {
+  await page.route('http://fhs.test/**', async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+
+    if (pathname === '/fixture') {
+      await route.fulfill({
+        contentType: 'text/html',
+        body: `
+          <div id="fixture"></div>
+          <script type="importmap">
+            {
+              "imports": {
+                "lit": "/node_modules/lit/index.js",
+                "lit-html": "/node_modules/lit-html/lit-html.js",
+                "lit-html/": "/node_modules/lit-html/",
+                "lit-element/": "/node_modules/lit-element/",
+                "@lit/reactive-element": "/node_modules/@lit/reactive-element/reactive-element.js",
+                "@lit/reactive-element/": "/node_modules/@lit/reactive-element/"
+              }
+            }
+          </script>
+          <script type="module">
+            import { render, svg } from 'lit';
+            import {
+              buildArcPathDefinition,
+              buildLinePathDefinition,
+              buildRectanglePathDefinition,
+              buildWavePathDefinition,
+            } from '/src/path-generators.js';
+            import { renderPathStrokeLayers } from '/src/path-renderer.js';
+
+            const definitions = [
+              buildArcPathDefinition({
+                cx: 50, cy: 50, radiusX: 35, radiusY: 35,
+                startAngle: 0, arcDegrees: 270,
+              }),
+              buildLinePathDefinition({ x1: 10, y1: 50, x2: 90, y2: 50 }),
+              buildRectanglePathDefinition({
+                x: 15, y: 15, width: 70, height: 70,
+                radiusTopLeft: 8, radiusTopRight: 8,
+                radiusBottomRight: 8, radiusBottomLeft: 8,
+                start: 'top', direction: 'clockwise',
+              }),
+              buildWavePathDefinition({
+                x1: 10, y1: 50, x2: 90, y2: 50,
+                waves: 2, amplitude: 12,
+              }),
+            ];
+            const background = {
+              color: '#444444', width: 10, opacity: 1, linecap: 'butt',
+            };
+            const ranges = [
+              {
+                id: 'low', color: '#00aa00', width: 8, opacity: 1,
+                startCap: 'butt', endCap: 'butt',
+                dash: { array: [35, 100], offset: 0 },
+              },
+              {
+                id: 'high', color: '#cc0000', width: 8, opacity: 1,
+                startCap: 'butt', endCap: 'butt',
+                dash: { array: [35, 100], offset: -40 },
+              },
+            ];
+
+            render(svg\`
+              <svg viewBox="0 0 220 220" width="440" height="440">
+                \${definitions.map((definition, index) => svg\`
+                  <g class="shape" data-index=\${index}
+                    transform="translate(\${(index % 2) * 110} \${Math.floor(index / 2) * 110})">
+                    \${renderPathStrokeLayers(definition, background, ranges, \`shape-\${index}\`)}
+                  </g>
+                \`)}
+              </svg>
+            \`, document.querySelector('#fixture'));
+            window.fixtureReady = true;
+          </script>
+        `,
+      });
+      return;
+    }
+
+    const source = await readFile(new URL(`..${pathname}`, import.meta.url));
+    await route.fulfill({ contentType: 'text/javascript', body: source });
+  });
+
+  await page.goto('http://fhs.test/fixture');
+  await page.waitForFunction(() => window.fixtureReady === true);
+
+  const renderedShapes = await page.evaluate(() => [...document.querySelectorAll('.shape')].map((shape) => {
+    const master = shape.querySelector('.path-stroke-renderer__master');
+    const background = shape.querySelector('.path-stroke-renderer__background');
+    const ranges = [...shape.querySelectorAll('.path-stroke-renderer__range')];
+    const totalLength = master.getTotalLength();
+    const pointAt = (progress) => master.getPointAtLength((progress / 100) * totalLength);
+    const isPaintedAt = (path, progress) => path.isPointInStroke(pointAt(progress));
+
+    return {
+      sameCenterline: [background, ...ranges].every((path) => path.getAttribute('d') === master.getAttribute('d')),
+      normalized: [master, background, ...ranges].every((path) => path.getAttribute('pathLength') === '100'),
+      backgroundAtGap: isPaintedAt(background, 37.5),
+      low: [20, 37.5, 50, 80].map((progress) => isPaintedAt(ranges[0], progress)),
+      high: [20, 37.5, 50, 80].map((progress) => isPaintedAt(ranges[1], progress)),
+    };
+  }));
+
+  expect(renderedShapes).toHaveLength(4);
+  renderedShapes.forEach((shape) => {
+    expect(shape).toEqual({
+      sameCenterline: true,
+      normalized: true,
+      backgroundAtGap: true,
+      low: [true, false, false, false],
+      high: [false, false, true, false],
+    });
+  });
+});

--- a/tests/path-renderer.test.js
+++ b/tests/path-renderer.test.js
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildArcPathDefinition,
+  buildLinePathDefinition,
+  buildRectanglePathDefinition,
+  buildWavePathDefinition,
+} from '../src/path-generators.js';
+import { renderPathStrokeLayers } from '../src/path-renderer.js';
+
+const pathDefinitions = [
+  buildArcPathDefinition({
+    cx: 50,
+    cy: 50,
+    radiusX: 40,
+    radiusY: 40,
+    startAngle: 0,
+    arcDegrees: 270,
+  }),
+  buildLinePathDefinition({ x1: 10, y1: 50, x2: 90, y2: 50 }),
+  buildRectanglePathDefinition({
+    x: 10,
+    y: 10,
+    width: 80,
+    height: 80,
+    radiusTopLeft: 8,
+    radiusTopRight: 8,
+    radiusBottomRight: 8,
+    radiusBottomLeft: 8,
+    start: 'top',
+    direction: 'clockwise',
+  }),
+  buildWavePathDefinition({
+    x1: 10,
+    y1: 50,
+    x2: 90,
+    y2: 50,
+    waves: 2,
+    amplitude: 12,
+  }),
+];
+const background = {
+  color: '#222222',
+  width: 10,
+  opacity: 0.4,
+  linecap: 'round',
+};
+const paintedRanges = [
+  {
+    id: 'low',
+    start: 0,
+    end: 35,
+    length: 35,
+    color: '#00aa00',
+    width: 8,
+    opacity: 0.8,
+    startCap: 'butt',
+    endCap: 'butt',
+    dash: { array: [35, 100], offset: 0 },
+  },
+  {
+    id: 'high',
+    start: 40,
+    end: 75,
+    length: 35,
+    color: '#cc0000',
+    width: 8,
+    opacity: 1,
+    startCap: 'butt',
+    endCap: 'butt',
+    dash: { array: [35, 100], offset: -40 },
+  },
+];
+
+test('every generated shape uses the same generic stroke and dash layers', () => {
+  pathDefinitions.forEach((pathDefinition, index) => {
+    const rendered = renderPathStrokeLayers(pathDefinition, background, paintedRanges, `path-${index}`);
+    const renderedRanges = rendered.values[10];
+
+    assert.equal(rendered.values[0], pathDefinition.signature);
+    assert.equal(rendered.values[3], pathDefinition.d);
+    assert.equal(rendered.values[5], pathDefinition.d);
+    assert.equal(rendered.values[6], background.color);
+    assert.equal(rendered.values[7], background.width);
+    assert.equal(rendered.values[8], background.opacity);
+    assert.equal(rendered.values[9], background.linecap);
+    assert.equal(renderedRanges.length, 2);
+
+    renderedRanges.forEach((range, rangeIndex) => {
+      assert.equal(range.values[3], pathDefinition.d);
+      assert.equal(range.values[4], paintedRanges[rangeIndex].color);
+      assert.equal(range.values[5], paintedRanges[rangeIndex].width);
+      assert.equal(range.values[6], paintedRanges[rangeIndex].opacity);
+      assert.equal(range.values[7], 'butt');
+      assert.equal(range.values[8], paintedRanges[rangeIndex].dash.array.join(' '));
+      assert.equal(range.values[9], paintedRanges[rangeIndex].dash.offset);
+    });
+  });
+});
+
+test('mixed endpoint caps stay exact until the dedicated mask renderer is added', () => {
+  const mixedRange = {
+    ...paintedRanges[0],
+    startCap: 'round',
+    endCap: 'butt',
+  };
+  const rendered = renderPathStrokeLayers(pathDefinitions[1], background, [mixedRange], 'mixed');
+
+  assert.equal(rendered.values[10][0].values[7], 'butt');
+});


### PR DESCRIPTION
Closes #576

- renders the background and normalized painted ranges from one shared centerline
- uses pathLength=100 for path-independent dash placement
- keeps arc, line, rectangle, and wave logic entirely in the path generators
- adds unit and Chromium coverage for all four path shapes

Validation:
- npm run build
- npm run test:browser