### PR TITLE
Horseshoe V3: add caps, masks, borders, and transparent fills

### DIFF
--- a/src/path-mask-renderer.js
+++ b/src/path-mask-renderer.js
@@ -1,0 +1,131 @@
+import { nothing, svg } from 'lit';
+
+/**
+ * Renders one normalized range as a butt-ended centerline plus independently
+ * selected round caps. Group opacity is applied after the overlapping base and
+ * cap strokes have been composed, so a transparent cap never becomes darker.
+ *
+ * @param {object} pathDefinition - Stable generated centerline definition.
+ * @param {object} range - Normalized range, dash placement, and endpoint caps.
+ * @param {object} paint - Complete stroke color and width.
+ * @param {string} className - CSS class namespace for the rendered stroke.
+ * @returns {TemplateResult} One composed normalized path stroke.
+ */
+function renderNormalizedPathStroke(pathDefinition, range, paint, className) {
+  const capDashLength = 0.001;
+  const caps = [
+    { location: 'start', type: range.startCap, progress: range.start },
+    { location: 'end', type: range.endCap, progress: range.end },
+  ];
+
+  return svg`
+    <g class=${className}>
+      <path
+        class="${className}__body"
+        d=${pathDefinition.d}
+        pathLength="100"
+        fill="none"
+        stroke=${paint.color}
+        stroke-width=${paint.width}
+        stroke-linecap="butt"
+        stroke-dasharray=${range.dash.array.join(' ')}
+        stroke-dashoffset=${range.dash.offset}
+      ></path>
+      ${caps.map((cap) => cap.type === 'round' ? svg`
+        <path
+          class="${className}__cap ${className}__cap--${cap.location}"
+          d=${pathDefinition.d}
+          pathLength="100"
+          fill="none"
+          stroke=${paint.color}
+          stroke-width=${paint.width}
+          stroke-linecap="round"
+          stroke-dasharray="${capDashLength} 100"
+          stroke-dashoffset=${-(cap.progress - capDashLength / 2)}
+        ></path>
+      ` : nothing)}
+    </g>
+  `;
+}
+
+/**
+ * Renders a path band with independent fill and border styling. The border is
+ * drawn wider than the fill and its center is removed with a luminance mask;
+ * a transparent fill therefore reveals the real underlying card instead of
+ * the border stroke.
+ *
+ * @param {object} pathDefinition - Stable generated centerline definition.
+ * @param {Array<object>} ranges - Complete normalized ranges for one visual layer.
+ * @param {object} layer - Shared fill, border, and composite opacity configuration.
+ * @param {string} layerId - Stable DOM namespace for masks and rendered paths.
+ * @param {string} className - CSS class namespace for the rendered bands.
+ * @returns {TemplateResult} Independently composited border and fill collections.
+ */
+export function renderNormalizedPathBands(pathDefinition, ranges, layer, layerId, className) {
+  return svg`
+    <g class=${className} opacity=${layer.opacity}>
+      ${layer.border.width > 0 ? svg`
+        <defs>
+          ${ranges.map((range) => {
+            const borderWidth = range.width + layer.border.width * 2;
+            const outerMaskPaint = { color: 'white', width: borderWidth };
+            const innerMaskPaint = { color: 'black', width: range.width };
+
+            return svg`
+              <mask
+                id="${layerId}-${range.id}-border-mask"
+                class="${className}__border-mask"
+                maskUnits="userSpaceOnUse"
+                maskContentUnits="userSpaceOnUse"
+                x="-100%"
+                y="-100%"
+                width="300%"
+                height="300%"
+                style="mask-type:luminance"
+              >
+                ${renderNormalizedPathStroke(pathDefinition, range, outerMaskPaint, `${className}__mask-outer`)}
+                ${renderNormalizedPathStroke(pathDefinition, range, innerMaskPaint, `${className}__mask-inner`)}
+              </mask>
+            `;
+          })}
+        </defs>
+        <g class="${className}__borders" opacity=${layer.strokeOpacity}>
+          ${ranges.map((range) => {
+            const borderPaint = {
+              color: layer.border.color,
+              width: range.width + layer.border.width * 2,
+            };
+
+            return svg`
+              <g
+                class="${className}__border"
+                data-path-range=${range.id}
+                opacity=${range.opacity}
+                mask="url(#${layerId}-${range.id}-border-mask)"
+              >
+                ${renderNormalizedPathStroke(pathDefinition, range, borderPaint, `${className}__border-stroke`)}
+              </g>
+            `;
+          })}
+        </g>
+      ` : nothing}
+      <g class="${className}__fills" opacity=${layer.fillOpacity}>
+        ${ranges.map((range) => {
+          const fillPaint = { color: range.color, width: range.width };
+
+          return svg`
+            <g
+              class="${className}__fill"
+              data-path-range=${range.id}
+              opacity=${range.opacity}
+            >
+              ${renderNormalizedPathStroke(pathDefinition, range, fillPaint, `${className}__fill-stroke`)}
+            </g>
+          `;
+        })}
+      </g>
+    </g>
+  `;
+}
+
+export default renderNormalizedPathBands;

--- a/src/path-renderer.js
+++ b/src/path-renderer.js
@@ -1,5 +1,7 @@
 import { svg } from 'lit';
 
+import { renderNormalizedPathBands } from './path-mask-renderer.js';
+
 /**
  * Renders one path centerline as a background track and normalized painted
  * ranges. Every visible layer reuses the same complete path definition;
@@ -7,11 +9,24 @@ import { svg } from 'lit';
  *
  * @param {object} pathDefinition - Stable generated centerline definition.
  * @param {object} background - Normalized background stroke configuration.
+ * @param {object} foreground - Shared foreground opacity and border configuration.
  * @param {Array<object>} paintedRanges - Normalized ranges from buildPaintedRanges().
  * @param {string} pathId - Stable DOM namespace for this rendered path.
  * @returns {TemplateResult} Generic SVG path layers.
  */
-export function renderPathStrokeLayers(pathDefinition, background, paintedRanges, pathId) {
+export function renderPathStrokeLayers(pathDefinition, background, foreground, paintedRanges, pathId) {
+  const backgroundRange = {
+    id: 'background',
+    start: 0,
+    end: 100,
+    color: background.color,
+    width: background.width,
+    opacity: 1,
+    startCap: background.startCap,
+    endCap: background.endCap,
+    dash: { array: [100, 100], offset: 0 },
+  };
+
   return svg`
     <g class="path-stroke-renderer" data-path-signature=${pathDefinition.signature}>
       <path
@@ -27,42 +42,24 @@ export function renderPathStrokeLayers(pathDefinition, background, paintedRanges
         pointer-events="none"
       ></path>
 
-      <path
-        id="${pathId}-background"
-        class="path-stroke-renderer__background"
-        d=${pathDefinition.d}
-        pathLength="100"
-        fill="none"
-        stroke=${background.color}
-        stroke-width=${background.width}
-        stroke-opacity=${background.opacity}
-        stroke-linecap=${background.linecap}
-        pointer-events="none"
-      ></path>
+      <g id="${pathId}-background" class="path-stroke-renderer__background" pointer-events="none">
+        ${renderNormalizedPathBands(
+          pathDefinition,
+          [backgroundRange],
+          background,
+          `${pathId}-background`,
+          'path-stroke-renderer__background-band',
+        )}
+      </g>
 
       <g class="path-stroke-renderer__ranges" pointer-events="none">
-        ${paintedRanges.map((range) => {
-          // Mixed endpoint caps require the mask layer added in #577. Until
-          // then, a mixed range stays geometrically exact with butt endpoints.
-          const linecap = range.startCap === range.endCap ? range.startCap : 'butt';
-
-          return svg`
-            <path
-              id="${pathId}-range-${range.id}"
-              class="path-stroke-renderer__range"
-              data-path-range=${range.id}
-              d=${pathDefinition.d}
-              pathLength="100"
-              fill="none"
-              stroke=${range.color}
-              stroke-width=${range.width}
-              stroke-opacity=${range.opacity}
-              stroke-linecap=${linecap}
-              stroke-dasharray=${range.dash.array.join(' ')}
-              stroke-dashoffset=${range.dash.offset}
-            ></path>
-          `;
-        })}
+        ${renderNormalizedPathBands(
+          pathDefinition,
+          paintedRanges,
+          foreground,
+          `${pathId}-ranges`,
+          'path-stroke-renderer__range-band',
+        )}
       </g>
     </g>
   `;

--- a/tests/path-renderer.browser.spec.js
+++ b/tests/path-renderer.browser.spec.js
@@ -51,29 +51,99 @@ test('generic renderer paints the same normalized ranges on every path shape', a
               }),
             ];
             const background = {
-              color: '#444444', width: 10, opacity: 1, linecap: 'butt',
+              color: '#444444', width: 10,
+              opacity: 1, fillOpacity: 1, strokeOpacity: 1,
+              border: { color: '#222222', width: 1 },
+              startCap: 'butt', endCap: 'butt',
+            };
+            const foreground = {
+              opacity: 1, fillOpacity: 0.25, strokeOpacity: 1,
+              border: { color: '#000000', width: 2 },
             };
             const ranges = [
               {
-                id: 'low', color: '#00aa00', width: 8, opacity: 1,
-                startCap: 'butt', endCap: 'butt',
+                id: 'low', start: 0, end: 35, color: '#00aa00', width: 8,
+                opacity: 1,
+                startCap: 'round', endCap: 'butt',
                 dash: { array: [35, 100], offset: 0 },
               },
               {
-                id: 'high', color: '#cc0000', width: 8, opacity: 1,
-                startCap: 'butt', endCap: 'butt',
+                id: 'high', start: 40, end: 75, color: '#cc0000', width: 8,
+                opacity: 1,
+                startCap: 'butt', endCap: 'round',
                 dash: { array: [35, 100], offset: -40 },
+              },
+            ];
+            const capCombinations = [
+              { id: 'butt-butt', startCap: 'butt', endCap: 'butt' },
+              { id: 'round-round', startCap: 'round', endCap: 'round' },
+              { id: 'round-butt', startCap: 'round', endCap: 'butt' },
+              { id: 'butt-round', startCap: 'butt', endCap: 'round' },
+            ];
+            const overlapBackground = {
+              color: 'transparent', width: 0,
+              opacity: 1, fillOpacity: 1, strokeOpacity: 1,
+              border: { color: 'transparent', width: 0 },
+              startCap: 'butt', endCap: 'butt',
+            };
+            const overlapForeground = {
+              opacity: 1, fillOpacity: 0.25, strokeOpacity: 1,
+              border: { color: 'transparent', width: 0 },
+            };
+            const overlapDefinition = buildLinePathDefinition({ x1: 10, y1: 0, x2: 210, y2: 0 });
+            const overlapRanges = [
+              {
+                id: 'first', start: 0, end: 51, color: '#00aa00', width: 8,
+                opacity: 1,
+                startCap: 'butt', endCap: 'butt', dash: { array: [51, 100], offset: 0 },
+              },
+              {
+                id: 'second', start: 49, end: 100, color: '#00aa00', width: 8,
+                opacity: 1,
+                startCap: 'butt', endCap: 'butt', dash: { array: [51, 100], offset: -49 },
               },
             ];
 
             render(svg\`
-              <svg viewBox="0 0 220 220" width="440" height="440">
+              <svg viewBox="0 0 220 240" width="220" height="240">
                 \${definitions.map((definition, index) => svg\`
                   <g class="shape" data-index=\${index}
                     transform="translate(\${(index % 2) * 110} \${Math.floor(index / 2) * 110})">
-                    \${renderPathStrokeLayers(definition, background, ranges, \`shape-\${index}\`)}
+                    \${renderPathStrokeLayers(definition, background, foreground, ranges, \`shape-\${index}\`)}
                   </g>
                 \`)}
+                <g class="opacity-overlap" transform="translate(0 225)">
+                  \${renderPathStrokeLayers(
+                    overlapDefinition,
+                    overlapBackground,
+                    overlapForeground,
+                    overlapRanges,
+                    'opacity-overlap',
+                  )}
+                </g>
+                <g class="cap-contracts" visibility="hidden">
+                  \${definitions.map((definition, shapeIndex) => capCombinations.map((combination) => svg\`
+                    <g class="cap-contract" data-shape=\${shapeIndex} data-combination=\${combination.id}>
+                      \${renderPathStrokeLayers(
+                        definition,
+                        background,
+                        foreground,
+                        [{
+                          id: combination.id,
+                          start: 20,
+                          end: 80,
+                          color: '#00aa00',
+                          width: 8,
+                          opacity: 1,
+                          startCap: combination.startCap,
+                          endCap: combination.endCap,
+                          dash: { array: [60, 100], offset: -20 },
+                        }],
+                        \`cap-\${shapeIndex}-\${combination.id}\`,
+                      )}
+                    </g>
+                  \`))}
+                </g>
               </svg>
             \`, document.querySelector('#fixture'));
             window.fixtureReady = true;
@@ -92,18 +162,24 @@ test('generic renderer paints the same normalized ranges on every path shape', a
 
   const renderedShapes = await page.evaluate(() => [...document.querySelectorAll('.shape')].map((shape) => {
     const master = shape.querySelector('.path-stroke-renderer__master');
-    const background = shape.querySelector('.path-stroke-renderer__background');
-    const ranges = [...shape.querySelectorAll('.path-stroke-renderer__range')];
+    const background = shape.querySelector('.path-stroke-renderer__background-band__fill-stroke__body');
+    const ranges = [...shape.querySelectorAll('.path-stroke-renderer__range-band__fill-stroke__body')];
+    const lowStartCap = shape.querySelector('.path-stroke-renderer__range-band__fill-stroke__cap--start');
+    const highEndCap = shape.querySelector('.path-stroke-renderer__range-band__fill-stroke__cap--end');
+    const renderedPaths = [...shape.querySelectorAll('path')];
     const totalLength = master.getTotalLength();
     const pointAt = (progress) => master.getPointAtLength((progress / 100) * totalLength);
     const isPaintedAt = (path, progress) => path.isPointInStroke(pointAt(progress));
 
     return {
-      sameCenterline: [background, ...ranges].every((path) => path.getAttribute('d') === master.getAttribute('d')),
-      normalized: [master, background, ...ranges].every((path) => path.getAttribute('pathLength') === '100'),
+      sameCenterline: renderedPaths.every((path) => path.getAttribute('d') === master.getAttribute('d')),
+      normalized: renderedPaths.every((path) => path.getAttribute('pathLength') === '100'),
       backgroundAtGap: isPaintedAt(background, 37.5),
       low: [20, 37.5, 50, 80].map((progress) => isPaintedAt(ranges[0], progress)),
       high: [20, 37.5, 50, 80].map((progress) => isPaintedAt(ranges[1], progress)),
+      lowStartCap: isPaintedAt(lowStartCap, 0),
+      highEndCap: isPaintedAt(highEndCap, 75),
+      fillCapCount: shape.querySelectorAll('.path-stroke-renderer__range-band__fill-stroke__cap').length,
     };
   }));
 
@@ -115,6 +191,73 @@ test('generic renderer paints the same normalized ranges on every path shape', a
       backgroundAtGap: true,
       low: [true, false, false, false],
       high: [false, false, true, false],
+      lowStartCap: true,
+      highEndCap: true,
+      fillCapCount: 2,
     });
   });
+
+  const capContracts = await page.evaluate(() => [...document.querySelectorAll('.cap-contract')].map((contract) => {
+    const master = contract.querySelector('.path-stroke-renderer__master');
+    const capPaths = [...contract.querySelectorAll('.path-stroke-renderer__range-band__fill-stroke__cap')];
+    const totalLength = master.getTotalLength();
+    const pointAt = (progress) => master.getPointAtLength((progress / 100) * totalLength);
+
+    return {
+      combination: contract.dataset.combination,
+      capCount: capPaths.length,
+      startPainted: capPaths.some((path) => path.isPointInStroke(pointAt(20))),
+      endPainted: capPaths.some((path) => path.isPointInStroke(pointAt(80))),
+    };
+  }));
+
+  expect(capContracts).toHaveLength(16);
+  capContracts.forEach((contract) => {
+    const expected = {
+      'butt-butt': { capCount: 0, startPainted: false, endPainted: false },
+      'round-round': { capCount: 2, startPainted: true, endPainted: true },
+      'round-butt': { capCount: 1, startPainted: true, endPainted: false },
+      'butt-round': { capCount: 1, startPainted: false, endPainted: true },
+    }[contract.combination];
+
+    expect(contract).toEqual({ combination: contract.combination, ...expected });
+  });
+
+  const linePixels = await page.evaluate(async () => {
+    const sourceSvg = document.querySelector('#fixture > svg');
+    const image = new Image();
+    const imageLoaded = new Promise((resolve, reject) => {
+      image.addEventListener('load', resolve, { once: true });
+      image.addEventListener('error', reject, { once: true });
+    });
+    const standaloneSvg = sourceSvg.outerHTML.replace('<svg ', '<svg xmlns="http://www.w3.org/2000/svg" ');
+    const imageUrl = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(standaloneSvg)}`;
+    image.src = imageUrl;
+    await imageLoaded;
+
+    const canvas = document.createElement('canvas');
+    canvas.width = 220;
+    canvas.height = 240;
+    const context = canvas.getContext('2d');
+    context.fillStyle = '#ffffff';
+    context.fillRect(0, 0, 220, 240);
+    context.drawImage(image, 0, 0, 220, 240);
+    const pixel = (x, y) => [...context.getImageData(x, y, 1, 1).data];
+    return {
+      roundCapOverlap: pixel(121, 50),
+      transparentFill: pixel(140, 50),
+      border: pixel(140, 45),
+      outside: pixel(140, 42),
+      gradientSegment: pixel(60, 225),
+      gradientOverlap: pixel(110, 225),
+    };
+  });
+
+  expect(linePixels.roundCapOverlap).toEqual(linePixels.transparentFill);
+  expect(linePixels.transparentFill[0]).toBeGreaterThan(40);
+  expect(linePixels.transparentFill[1]).toBeGreaterThan(85);
+  expect(linePixels.border[0]).toBeLessThan(25);
+  expect(linePixels.border[1]).toBeLessThan(25);
+  expect(linePixels.outside).toEqual([255, 255, 255, 255]);
+  expect(linePixels.gradientOverlap).toEqual(linePixels.gradientSegment);
 });

--- a/tests/path-renderer.test.js
+++ b/tests/path-renderer.test.js
@@ -7,6 +7,7 @@ import {
   buildRectanglePathDefinition,
   buildWavePathDefinition,
 } from '../src/path-generators.js';
+import { renderNormalizedPathBands } from '../src/path-mask-renderer.js';
 import { renderPathStrokeLayers } from '../src/path-renderer.js';
 
 const pathDefinitions = [
@@ -43,8 +44,18 @@ const pathDefinitions = [
 const background = {
   color: '#222222',
   width: 10,
-  opacity: 0.4,
-  linecap: 'round',
+  opacity: 1,
+  fillOpacity: 0.4,
+  strokeOpacity: 0.7,
+  border: { color: '#111111', width: 1 },
+  startCap: 'round',
+  endCap: 'round',
+};
+const foreground = {
+  opacity: 0.9,
+  fillOpacity: 0.8,
+  strokeOpacity: 0.6,
+  border: { color: '#111111', width: 2 },
 };
 const paintedRanges = [
   {
@@ -75,37 +86,82 @@ const paintedRanges = [
 
 test('every generated shape uses the same generic stroke and dash layers', () => {
   pathDefinitions.forEach((pathDefinition, index) => {
-    const rendered = renderPathStrokeLayers(pathDefinition, background, paintedRanges, `path-${index}`);
-    const renderedRanges = rendered.values[10];
+    const rendered = renderPathStrokeLayers(
+      pathDefinition,
+      background,
+      foreground,
+      paintedRanges,
+      `path-${index}`,
+    );
+    const renderedBackground = rendered.values[5];
+    const renderedRanges = rendered.values[6];
 
     assert.equal(rendered.values[0], pathDefinition.signature);
     assert.equal(rendered.values[3], pathDefinition.d);
-    assert.equal(rendered.values[5], pathDefinition.d);
-    assert.equal(rendered.values[6], background.color);
-    assert.equal(rendered.values[7], background.width);
-    assert.equal(rendered.values[8], background.opacity);
-    assert.equal(rendered.values[9], background.linecap);
-    assert.equal(renderedRanges.length, 2);
+    assert.equal(renderedBackground.values[1], background.opacity);
+    assert.equal(renderedBackground.values[4], background.fillOpacity);
+    assert.equal(renderedRanges.values[1], foreground.opacity);
+    assert.equal(renderedRanges.values[4], foreground.fillOpacity);
+    assert.equal(renderedRanges.values[5].length, 2);
 
-    renderedRanges.forEach((range, rangeIndex) => {
-      assert.equal(range.values[3], pathDefinition.d);
-      assert.equal(range.values[4], paintedRanges[rangeIndex].color);
-      assert.equal(range.values[5], paintedRanges[rangeIndex].width);
-      assert.equal(range.values[6], paintedRanges[rangeIndex].opacity);
-      assert.equal(range.values[7], 'butt');
-      assert.equal(range.values[8], paintedRanges[rangeIndex].dash.array.join(' '));
-      assert.equal(range.values[9], paintedRanges[rangeIndex].dash.offset);
+    renderedRanges.values[5].forEach((range, rangeIndex) => {
+      const fillStroke = range.values[3];
+
+      assert.equal(range.values[2], paintedRanges[rangeIndex].opacity);
+      assert.equal(fillStroke.values[2], pathDefinition.d);
+      assert.equal(fillStroke.values[3], paintedRanges[rangeIndex].color);
+      assert.equal(fillStroke.values[4], paintedRanges[rangeIndex].width);
+      assert.equal(fillStroke.values[5], paintedRanges[rangeIndex].dash.array.join(' '));
+      assert.equal(fillStroke.values[6], paintedRanges[rangeIndex].dash.offset);
     });
   });
 });
 
-test('mixed endpoint caps stay exact until the dedicated mask renderer is added', () => {
-  const mixedRange = {
-    ...paintedRanges[0],
-    startCap: 'round',
-    endCap: 'butt',
-  };
-  const rendered = renderPathStrokeLayers(pathDefinitions[1], background, [mixedRange], 'mixed');
+test('all endpoint cap combinations add round strokes only where selected', () => {
+  [
+    { startCap: 'butt', endCap: 'butt', expected: [] },
+    { startCap: 'round', endCap: 'round', expected: ['start', 'end'] },
+    { startCap: 'round', endCap: 'butt', expected: ['start'] },
+    { startCap: 'butt', endCap: 'round', expected: ['end'] },
+  ].forEach((combination, index) => {
+    const range = { ...paintedRanges[0], ...combination };
+    const rendered = renderNormalizedPathBands(
+      pathDefinitions[1],
+      [range],
+      foreground,
+      `caps-${index}`,
+      'caps-band',
+    );
+    const fillStroke = rendered.values[5][0].values[3];
+    const renderedCaps = fillStroke.values[7]
+      .filter((cap) => typeof cap !== 'symbol')
+      .map((cap) => cap.values[2]);
 
-  assert.equal(rendered.values[10][0].values[7], 'butt');
+    assert.deepEqual(renderedCaps, combination.expected);
+  });
+});
+
+test('border mask removes the complete fill width from a wider independent border', () => {
+  const rendered = renderNormalizedPathBands(
+    pathDefinitions[1],
+    [paintedRanges[0]],
+    foreground,
+    'bordered',
+    'bordered-band',
+  );
+  const borderLayers = rendered.values[2];
+  const borderMask = borderLayers.values[0][0];
+  const outerMaskStroke = borderMask.values[3];
+  const innerMaskStroke = borderMask.values[4];
+  const visibleBorderRange = borderLayers.values[3][0];
+  const visibleBorderStroke = visibleBorderRange.values[5];
+
+  assert.equal(outerMaskStroke.values[3], 'white');
+  assert.equal(outerMaskStroke.values[4], 12);
+  assert.equal(innerMaskStroke.values[3], 'black');
+  assert.equal(innerMaskStroke.values[4], 8);
+  assert.equal(visibleBorderStroke.values[3], '#111111');
+  assert.equal(visibleBorderStroke.values[4], 12);
+  assert.equal(visibleBorderRange.values[2], paintedRanges[0].opacity);
+  assert.equal(borderLayers.values[2], 0.6);
 });


### PR DESCRIPTION
Closes #577

- renders butt and round caps independently on every admitted path
- uses masks for independent borders around transparent fills
- composites shared layer opacity after overlapping stroke parts
- preserves per-range opacity for discrete string-state styling
- verifies arc, line, rectangle, and wave contracts in Chromium