### PR TITLE
Horseshoe V3: add spiral and infinity stress geometries

### DIFF
--- a/src/path-generators.js
+++ b/src/path-generators.js
@@ -142,6 +142,67 @@ export function buildWavePathDefinition(config) {
 }
 
 /**
+ * Builds an Archimedean spiral from configured inner to outer radius. Sampled
+ * points are joined as one Catmull-Rom-derived cubic spline so the browser sees
+ * a smooth centerline instead of a chain of tangent-breaking line segments.
+ *
+ * @param {object} config - Normalized spiral center, radii, sweep, and point count.
+ * @returns {object} Stable spiral path definition.
+ */
+export function buildSpiralPathDefinition(config) {
+  const points = [];
+
+  for (let index = 0; index <= config.points; index += 1) {
+    const progress = index / config.points;
+    const radius = config.radiusInner + (config.radiusOuter - config.radiusInner) * progress;
+    const angle = ((config.startAngle + config.degrees * progress) * Math.PI) / 180;
+
+    points.push({
+      x: config.cx + radius * Math.cos(angle),
+      y: config.cy + radius * Math.sin(angle),
+    });
+  }
+
+  const commands = [`M ${points[0].x} ${points[0].y}`];
+
+  for (let index = 0; index < points.length - 1; index += 1) {
+    const previous = points[Math.max(0, index - 1)];
+    const current = points[index];
+    const next = points[index + 1];
+    const following = points[Math.min(points.length - 1, index + 2)];
+    const controlOneX = current.x + (next.x - previous.x) / 6;
+    const controlOneY = current.y + (next.y - previous.y) / 6;
+    const controlTwoX = next.x - (following.x - current.x) / 6;
+    const controlTwoY = next.y - (following.y - current.y) / 6;
+
+    commands.push(`C ${controlOneX} ${controlOneY} ${controlTwoX} ${controlTwoY} ${next.x} ${next.y}`);
+  }
+
+  return createPathDefinition(commands.join(' '), false);
+}
+
+/**
+ * Builds a closed figure-eight centerline. Four cubic sections preserve the
+ * tangent through both outer turns, the center crossing, and the closing seam.
+ *
+ * @param {object} config - Normalized infinity center and horizontal/vertical radii.
+ * @returns {object} Stable self-intersecting path definition.
+ */
+export function buildInfinityPathDefinition(config) {
+  const halfControlX = config.radiusX / 2;
+  const d = [
+    `M ${config.cx} ${config.cy}`,
+    `C ${config.cx + halfControlX} ${config.cy - config.radiusY} ${config.cx + config.radiusX} ${config.cy - config.radiusY} ${config.cx + config.radiusX} ${config.cy}`,
+    `C ${config.cx + config.radiusX} ${config.cy + config.radiusY} ${config.cx + halfControlX} ${config.cy + config.radiusY} ${config.cx} ${config.cy}`,
+    `C ${config.cx - halfControlX} ${config.cy - config.radiusY} ${config.cx - config.radiusX} ${config.cy - config.radiusY} ${config.cx - config.radiusX} ${config.cy}`,
+    `C ${config.cx - config.radiusX} ${config.cy + config.radiusY} ${config.cx - halfControlX} ${config.cy + config.radiusY} ${config.cx} ${config.cy}`,
+    'Z',
+  ].join(' ');
+
+  return createPathDefinition(d, true);
+}
+
+/**
  * Dispatches normalized shape configuration to its centerline generator.
  *
  * @param {object} config - Normalized path geometry with a supported type.
@@ -157,5 +218,9 @@ export function buildPathDefinition(config) {
       return buildRectanglePathDefinition(config);
     case 'wave':
       return buildWavePathDefinition(config);
+    case 'spiral':
+      return buildSpiralPathDefinition(config);
+    case 'infinity':
+      return buildInfinityPathDefinition(config);
   }
 }

--- a/tests/path-generators.test.js
+++ b/tests/path-generators.test.js
@@ -3,9 +3,11 @@ import test from 'node:test';
 
 import {
   buildArcPathDefinition,
+  buildInfinityPathDefinition,
   buildLinePathDefinition,
   buildPathDefinition,
   buildRectanglePathDefinition,
+  buildSpiralPathDefinition,
   buildWavePathDefinition,
 } from '../src/path-generators.js';
 
@@ -137,4 +139,45 @@ test('wave generator applies amplitude perpendicular to a vertical baseline', ()
 
   assert.match(definition.d, /^M 50 10 C 38 /);
   assert.match(definition.d, /50 90$/);
+});
+
+test('spiral generator follows the configured radii and sweep as one smooth path', () => {
+  const config = {
+    type: 'spiral',
+    cx: 50,
+    cy: 50,
+    radiusInner: 5,
+    radiusOuter: 40,
+    startAngle: -90,
+    degrees: 720,
+    points: 48,
+  };
+  const definition = buildSpiralPathDefinition(config);
+  const dispatched = buildPathDefinition(config);
+
+  assert.equal(definition.closed, false);
+  assert.match(definition.d, /^M 50 45 C /);
+  assert.equal((definition.d.match(/ C /g) ?? []).length, 48);
+  const [, endX, endY] = definition.d.match(/ ([^ ]+) ([^ ]+)$/);
+  assert.ok(Math.abs(Number(endX) - 50) < 1e-10);
+  assert.equal(Number(endY), 10);
+  assert.equal(dispatched.signature, definition.signature);
+});
+
+test('infinity generator closes one tangent-continuous self-intersecting path', () => {
+  const config = {
+    type: 'infinity',
+    cx: 50,
+    cy: 50,
+    radiusX: 40,
+    radiusY: 25,
+  };
+  const definition = buildInfinityPathDefinition(config);
+  const dispatched = buildPathDefinition(config);
+
+  assert.equal(definition.closed, true);
+  assert.match(definition.d, /^M 50 50 C 70 25 90 25 90 50 /);
+  assert.equal((definition.d.match(/ C /g) ?? []).length, 4);
+  assert.match(definition.d, /C 10 75 30 75 50 50 Z$/);
+  assert.equal(dispatched.signature, definition.signature);
 });

--- a/tests/path-renderer.browser.spec.js
+++ b/tests/path-renderer.browser.spec.js
@@ -27,8 +27,10 @@ test('generic renderer paints the same normalized ranges on every path shape', a
             import { render, svg } from 'lit';
             import {
               buildArcPathDefinition,
+              buildInfinityPathDefinition,
               buildLinePathDefinition,
               buildRectanglePathDefinition,
+              buildSpiralPathDefinition,
               buildWavePathDefinition,
             } from '/src/path-generators.js';
             import { renderPathStrokeLayers } from '/src/path-renderer.js';
@@ -48,6 +50,14 @@ test('generic renderer paints the same normalized ranges on every path shape', a
               buildWavePathDefinition({
                 x1: 10, y1: 50, x2: 90, y2: 50,
                 waves: 2, amplitude: 12,
+              }),
+              buildSpiralPathDefinition({
+                cx: 50, cy: 50,
+                radiusInner: 5, radiusOuter: 40,
+                startAngle: -90, degrees: 720, points: 48,
+              }),
+              buildInfinityPathDefinition({
+                cx: 50, cy: 50, radiusX: 40, radiusY: 25,
               }),
             ];
             const background = {
@@ -105,14 +115,14 @@ test('generic renderer paints the same normalized ranges on every path shape', a
             ];
 
             render(svg\`
-              <svg viewBox="0 0 220 240" width="220" height="240">
+              <svg viewBox="0 0 220 350" width="220" height="350">
                 \${definitions.map((definition, index) => svg\`
                   <g class="shape" data-index=\${index}
                     transform="translate(\${(index % 2) * 110} \${Math.floor(index / 2) * 110})">
                     \${renderPathStrokeLayers(definition, background, foreground, ranges, \`shape-\${index}\`)}
                   </g>
                 \`)}
-                <g class="opacity-overlap" transform="translate(0 225)">
+                <g class="opacity-overlap" transform="translate(0 335)">
                   \${renderPathStrokeLayers(
                     overlapDefinition,
                     overlapBackground,
@@ -172,6 +182,7 @@ test('generic renderer paints the same normalized ranges on every path shape', a
     const isPaintedAt = (path, progress) => path.isPointInStroke(pointAt(progress));
 
     return {
+      shapeIndex: Number(shape.dataset.index),
       sameCenterline: renderedPaths.every((path) => path.getAttribute('d') === master.getAttribute('d')),
       normalized: renderedPaths.every((path) => path.getAttribute('pathLength') === '100'),
       backgroundAtGap: isPaintedAt(background, 37.5),
@@ -183,13 +194,14 @@ test('generic renderer paints the same normalized ranges on every path shape', a
     };
   }));
 
-  expect(renderedShapes).toHaveLength(4);
-  renderedShapes.forEach((shape) => {
+  expect(renderedShapes).toHaveLength(6);
+  renderedShapes.forEach((shape, shapeIndex) => {
     expect(shape).toEqual({
+      shapeIndex,
       sameCenterline: true,
       normalized: true,
       backgroundAtGap: true,
-      low: [true, false, false, false],
+      low: shapeIndex === 5 ? [true, false, true, false] : [true, false, false, false],
       high: [false, false, true, false],
       lowStartCap: true,
       highEndCap: true,
@@ -211,7 +223,7 @@ test('generic renderer paints the same normalized ranges on every path shape', a
     };
   }));
 
-  expect(capContracts).toHaveLength(16);
+  expect(capContracts).toHaveLength(24);
   capContracts.forEach((contract) => {
     const expected = {
       'butt-butt': { capCount: 0, startPainted: false, endPainted: false },
@@ -237,19 +249,19 @@ test('generic renderer paints the same normalized ranges on every path shape', a
 
     const canvas = document.createElement('canvas');
     canvas.width = 220;
-    canvas.height = 240;
+    canvas.height = 350;
     const context = canvas.getContext('2d');
     context.fillStyle = '#ffffff';
-    context.fillRect(0, 0, 220, 240);
-    context.drawImage(image, 0, 0, 220, 240);
+    context.fillRect(0, 0, 220, 350);
+    context.drawImage(image, 0, 0, 220, 350);
     const pixel = (x, y) => [...context.getImageData(x, y, 1, 1).data];
     return {
       roundCapOverlap: pixel(121, 50),
       transparentFill: pixel(140, 50),
       border: pixel(140, 45),
       outside: pixel(140, 42),
-      gradientSegment: pixel(60, 225),
-      gradientOverlap: pixel(110, 225),
+      gradientSegment: pixel(60, 335),
+      gradientOverlap: pixel(110, 335),
     };
   });
 

--- a/tests/path-renderer.test.js
+++ b/tests/path-renderer.test.js
@@ -3,8 +3,10 @@ import test from 'node:test';
 
 import {
   buildArcPathDefinition,
+  buildInfinityPathDefinition,
   buildLinePathDefinition,
   buildRectanglePathDefinition,
+  buildSpiralPathDefinition,
   buildWavePathDefinition,
 } from '../src/path-generators.js';
 import { renderNormalizedPathBands } from '../src/path-mask-renderer.js';
@@ -39,6 +41,21 @@ const pathDefinitions = [
     y2: 50,
     waves: 2,
     amplitude: 12,
+  }),
+  buildSpiralPathDefinition({
+    cx: 50,
+    cy: 50,
+    radiusInner: 5,
+    radiusOuter: 40,
+    startAngle: -90,
+    degrees: 720,
+    points: 48,
+  }),
+  buildInfinityPathDefinition({
+    cx: 50,
+    cy: 50,
+    radiusX: 40,
+    radiusY: 25,
   }),
 ];
 const background = {

--- a/tests/svg-geometry.browser.spec.js
+++ b/tests/svg-geometry.browser.spec.js
@@ -280,6 +280,23 @@ test('all initial path generators produce measurable centerlines with stable end
         waves: 3,
         amplitude: 12,
       },
+      {
+        type: 'spiral',
+        cx: 70,
+        cy: 70,
+        radiusInner: 5,
+        radiusOuter: 55,
+        startAngle: -90,
+        degrees: 1080,
+        points: 72,
+      },
+      {
+        type: 'infinity',
+        cx: 70,
+        cy: 50,
+        radiusX: 55,
+        radiusY: 30,
+      },
     ];
     const measurements = configs.map((config) => {
       const definition = buildPathDefinition(config);
@@ -304,7 +321,7 @@ test('all initial path generators produce measurable centerlines with stable end
     return measurements;
   }, pathGeneratorSource);
 
-  const [arc, line, rectangle, wave] = generatedPaths;
+  const [arc, line, rectangle, wave, spiral, infinity] = generatedPaths;
 
   expect(arc.length).toBeCloseTo(Math.PI * 20, 1);
   expect(arc.start.x).toBeCloseTo(90, 4);
@@ -325,6 +342,18 @@ test('all initial path generators produce measurable centerlines with stable end
   expect(wave.start).toEqual({ x: 10, y: 50 });
   expect(wave.end.x).toBeCloseTo(130, 4);
   expect(wave.end.y).toBeCloseTo(50, 4);
+
+  expect(spiral.closed).toBe(false);
+  expect(spiral.length).toBeGreaterThan(500);
+  expect(spiral.start.x).toBeCloseTo(70, 4);
+  expect(spiral.start.y).toBeCloseTo(65, 4);
+  expect(spiral.end.x).toBeCloseTo(70, 4);
+  expect(spiral.end.y).toBeCloseTo(15, 4);
+
+  expect(infinity.closed).toBe(true);
+  expect(infinity.length).toBeGreaterThan(200);
+  expect(infinity.start).toEqual({ x: 70, y: 50 });
+  expect(infinity.end).toEqual({ x: 70, y: 50 });
 });
 
 test('shared measured geometry handles every initial shape, boundaries, corners, cusps, and seams', async ({ page }) => {
@@ -377,6 +406,23 @@ test('shared measured geometry handles every initial shape, boundaries, corners,
         y2: 50,
         waves: 3,
         amplitude: 12,
+      },
+      {
+        type: 'spiral',
+        cx: 70,
+        cy: 70,
+        radiusInner: 5,
+        radiusOuter: 55,
+        startAngle: -90,
+        degrees: 1080,
+        points: 72,
+      },
+      {
+        type: 'infinity',
+        cx: 70,
+        cy: 50,
+        radiusX: 55,
+        radiusY: 30,
       },
     ];
     const sharedContracts = configs.map((config) => {
@@ -439,6 +485,25 @@ test('shared measured geometry handles every initial shape, boundaries, corners,
     cuspGeometry.bindPathElement(cuspPath);
     const cuspTangent = cuspGeometry.tangentAtProgress(50);
 
+    // A self-intersection has two traversal positions at one physical point.
+    // Its local tangent must remain continuous through the crossing, while the
+    // closed seam must return with the same direction with which it started.
+    const infinityDefinition = buildPathDefinition(configs[5]);
+    const infinityPath = svg.querySelectorAll('path')[5];
+    const infinityGeometry = new PathGeometry(() => {});
+    infinityGeometry.setPathDefinition(infinityDefinition);
+    infinityGeometry.bindPathElement(infinityPath);
+    const infinityCrossing = {
+      before: infinityGeometry.tangentAtProgress(49.9),
+      at: infinityGeometry.tangentAtProgress(50),
+      after: infinityGeometry.tangentAtProgress(50.1),
+      point: infinityGeometry.pointAtProgress(50),
+    };
+    const infinitySeam = {
+      start: infinityGeometry.tangentAtProgress(0),
+      end: infinityGeometry.tangentAtProgress(100),
+    };
+
     URL.revokeObjectURL(geometryModuleUrl);
     URL.revokeObjectURL(generatorModuleUrl);
     return {
@@ -449,6 +514,8 @@ test('shared measured geometry handles every initial shape, boundaries, corners,
       seamStart,
       seamEnd,
       cuspTangent,
+      infinityCrossing,
+      infinitySeam,
     };
   }, {
     geometrySource: pathGeometrySource,
@@ -477,4 +544,12 @@ test('shared measured geometry handles every initial shape, boundaries, corners,
   expect(geometryContracts.seamStart.y).toBeCloseTo(geometryContracts.seamEnd.y, 5);
   expect(geometryContracts.cuspTangent.x).toBeCloseTo(-1, 5);
   expect(geometryContracts.cuspTangent.y).toBeCloseTo(0, 3);
+  expect(geometryContracts.infinityCrossing.point.x).toBeCloseTo(70, 4);
+  expect(geometryContracts.infinityCrossing.point.y).toBeCloseTo(50, 4);
+  expect(geometryContracts.infinityCrossing.before.x).toBeCloseTo(geometryContracts.infinityCrossing.at.x, 2);
+  expect(geometryContracts.infinityCrossing.before.y).toBeCloseTo(geometryContracts.infinityCrossing.at.y, 2);
+  expect(geometryContracts.infinityCrossing.after.x).toBeCloseTo(geometryContracts.infinityCrossing.at.x, 2);
+  expect(geometryContracts.infinityCrossing.after.y).toBeCloseTo(geometryContracts.infinityCrossing.at.y, 2);
+  expect(geometryContracts.infinitySeam.start.x).toBeCloseTo(geometryContracts.infinitySeam.end.x, 5);
+  expect(geometryContracts.infinitySeam.start.y).toBeCloseTo(geometryContracts.infinitySeam.end.y, 5);
 });


### PR DESCRIPTION
Closes #578

- adds a smooth Archimedean spiral centerline
- adds a closed tangent-continuous infinity centerline
- runs both through shared browser geometry, ranges, caps, masks, and renderer contracts
- records deterministic overlap behavior at the infinity crossing
- keeps helix variants outside this geometry proof and before the public config freeze