### PR TITLE
Horseshoe V3: implement adaptive path gradients

### DIFF
--- a/src/path-gradient-renderer.js
+++ b/src/path-gradient-renderer.js
@@ -1,0 +1,180 @@
+import { svg } from 'lit';
+
+import Colors from './colors.js';
+import { renderNormalizedPathBands } from './path-mask-renderer.js';
+
+/**
+ * Builds an adaptive sequence of locally linear gradient strokes along one
+ * measured centerline. Full gradients keep a static 0..100 color distribution
+ * while their visible dash range moves; current gradients redistribute the
+ * complete color sequence over the active range.
+ *
+ * @param {PathGeometry} pathGeometry - Bound browser-measured path geometry.
+ * @param {object} config - Complete normalized gradient, range, cap, and cost contract.
+ * @returns {object} Gradient micro-ranges and the independently movable reveal range.
+ */
+export function buildAdaptivePathGradient(pathGeometry, config) {
+  const domainStart = config.mode === 'full' ? 0 : config.range.start;
+  const domainEnd = config.mode === 'full' ? 100 : config.range.end;
+  const colorStops = { colors: config.colorStops.map((stop) => ({ value: stop.progress, color: stop.color })) };
+  const anchors = [
+    domainStart,
+    ...config.colorStops.map((stop) => domainStart + (stop.progress / 100) * (domainEnd - domainStart)),
+    domainEnd,
+  ]
+    .sort((progressA, progressB) => progressA - progressB)
+    .filter((progress, index, values) => values.indexOf(progress) === index);
+  const pendingIntervals = anchors.slice(0, -1).map((start, index) => ({ start, end: anchors[index + 1] })).reverse();
+  const adaptiveIntervals = [];
+
+  // Split by measured length before asking the browser for coordinates. Once
+  // an interval is short enough, its two chord directions reveal local curve
+  // change with one cached start/middle/end sample each. A true corner stops at
+  // the configured visible minimum instead of subdividing toward zero forever.
+  while (pendingIntervals.length) {
+    const interval = pendingIntervals.pop();
+    const midpoint = (interval.start + interval.end) / 2;
+    const intervalLength = ((interval.end - interval.start) / 100) * pathGeometry.getTotalLength();
+    const splitFitsDomBudget = adaptiveIntervals.length + pendingIntervals.length + 2 <= config.maxSegments;
+
+    if (intervalLength > config.maxSegmentLength && splitFitsDomBudget) {
+      pendingIntervals.push({ start: midpoint, end: interval.end });
+      pendingIntervals.push({ start: interval.start, end: midpoint });
+      continue;
+    }
+
+    const startPoint = pathGeometry.pointAtProgress(interval.start);
+    const middlePoint = pathGeometry.pointAtProgress(midpoint);
+    const endPoint = pathGeometry.pointAtProgress(interval.end);
+    const firstChord = { x: middlePoint.x - startPoint.x, y: middlePoint.y - startPoint.y };
+    const secondChord = { x: endPoint.x - middlePoint.x, y: endPoint.y - middlePoint.y };
+    const firstChordLength = Math.hypot(firstChord.x, firstChord.y);
+    const secondChordLength = Math.hypot(secondChord.x, secondChord.y);
+    const chordDotProduct = (firstChord.x * secondChord.x + firstChord.y * secondChord.y) / (firstChordLength * secondChordLength);
+    const chordAngle = Math.acos(Math.min(1, Math.max(-1, chordDotProduct))) * 180 / Math.PI;
+
+    if (chordAngle > config.maxTangentAngle && intervalLength / 2 >= config.minSegmentLength && splitFitsDomBudget) {
+      pendingIntervals.push({ start: midpoint, end: interval.end });
+      pendingIntervals.push({ start: interval.start, end: midpoint });
+      continue;
+    }
+
+    adaptiveIntervals.push(interval);
+  }
+
+  const ranges = adaptiveIntervals.map((interval, index) => {
+    const gradientStartProgress = ((interval.start - domainStart) / (domainEnd - domainStart)) * 100;
+    const gradientEndProgress = ((interval.end - domainStart) / (domainEnd - domainStart)) * 100;
+    const startPoint = pathGeometry.pointAtProgress(interval.start);
+    const endPoint = pathGeometry.pointAtProgress(interval.end);
+    const overlapEnd = index === adaptiveIntervals.length - 1
+      ? interval.end
+      : Math.min(domainEnd, interval.end + (interval.end - interval.start) * config.overlap);
+    const length = overlapEnd - interval.start;
+
+    return {
+      id: `gradient-${index}`,
+      start: interval.start,
+      end: overlapEnd,
+      length,
+      width: config.width,
+      opacity: 1,
+      startCap: index === 0 ? config.startCap : 'butt',
+      endCap: index === adaptiveIntervals.length - 1 ? config.endCap : 'butt',
+      dash: {
+        array: [length, 100],
+        offset: interval.start === 0 ? 0 : -interval.start,
+      },
+      gradient: {
+        x1: startPoint.x,
+        y1: startPoint.y,
+        x2: endPoint.x,
+        y2: endPoint.y,
+        startColor: Colors.calculateStrokeColor(gradientStartProgress, colorStops, true),
+        endColor: Colors.calculateStrokeColor(gradientEndProgress, colorStops, true),
+      },
+    };
+  });
+  const revealLength = config.range.end - config.range.start;
+
+  return {
+    mode: config.mode,
+    ranges,
+    revealRange: {
+      id: 'gradient-reveal',
+      start: config.range.start,
+      end: config.range.end,
+      startCap: config.startCap,
+      endCap: config.endCap,
+      dash: {
+        array: [revealLength, 100],
+        offset: config.range.start === 0 ? 0 : -config.range.start,
+      },
+    },
+  };
+}
+
+/**
+ * Renders adaptive gradient ranges through the same generic band, border, cap,
+ * and transparency pipeline as solid ranges. Full gradients are clipped by a
+ * normalized dash intersections so state-only updates do not rebuild colors
+ * and self-intersections never reveal a different path position.
+ *
+ * @param {object} pathDefinition - Stable generated centerline definition.
+ * @param {object} gradient - Result from buildAdaptivePathGradient().
+ * @param {object} layer - Shared fill, border, and composite opacity configuration.
+ * @param {string} layerId - Stable DOM namespace for gradient definitions.
+ * @param {string} className - CSS class namespace for the rendered gradient.
+ * @returns {TemplateResult} Generic path gradient bands.
+ */
+export function renderAdaptivePathGradient(pathDefinition, gradient, layer, layerId, className) {
+  const visibleRanges = gradient.ranges
+    .map((range) => {
+      const start = Math.max(range.start, gradient.revealRange.start);
+      const end = Math.min(range.end, gradient.revealRange.end);
+      const length = end - start;
+
+      return {
+        ...range,
+        start,
+        end,
+        length,
+        color: `url(#${layerId}-${range.id})`,
+        dash: {
+          array: [length, 100],
+          offset: start === 0 ? 0 : -start,
+        },
+      };
+    })
+    .filter((range) => range.end > range.start)
+    .map((range, index, ranges) => ({
+      ...range,
+      startCap: index === 0 ? gradient.revealRange.startCap : 'butt',
+      endCap: index === ranges.length - 1 ? gradient.revealRange.endCap : 'butt',
+    }));
+
+  return svg`
+    <g class=${className}>
+      <defs>
+        ${gradient.ranges.map((range) => svg`
+          <linearGradient
+            id="${layerId}-${range.id}"
+            gradientUnits="userSpaceOnUse"
+            x1=${range.gradient.x1}
+            y1=${range.gradient.y1}
+            x2=${range.gradient.x2}
+            y2=${range.gradient.y2}
+          >
+            <stop offset="0%" stop-color=${range.gradient.startColor}></stop>
+            <stop offset="100%" stop-color=${range.gradient.endColor}></stop>
+          </linearGradient>
+        `)}
+      </defs>
+      <g class="${className}__bands">
+        ${renderNormalizedPathBands(pathDefinition, visibleRanges, layer, `${layerId}-bands`, `${className}__band`)}
+      </g>
+    </g>
+  `;
+}
+
+export default renderAdaptivePathGradient;

--- a/src/path-mask-renderer.js
+++ b/src/path-mask-renderer.js
@@ -11,7 +11,7 @@ import { nothing, svg } from 'lit';
  * @param {string} className - CSS class namespace for the rendered stroke.
  * @returns {TemplateResult} One composed normalized path stroke.
  */
-function renderNormalizedPathStroke(pathDefinition, range, paint, className) {
+export function renderNormalizedPathStroke(pathDefinition, range, paint, className) {
   const capDashLength = 0.001;
   const caps = [
     { location: 'start', type: range.startCap, progress: range.start },
@@ -40,7 +40,7 @@ function renderNormalizedPathStroke(pathDefinition, range, paint, className) {
           stroke=${paint.color}
           stroke-width=${paint.width}
           stroke-linecap="round"
-          stroke-dasharray="${capDashLength} 100"
+          stroke-dasharray="${capDashLength} 200"
           stroke-dashoffset=${-(cap.progress - capDashLength / 2)}
         ></path>
       ` : nothing)}

--- a/tests/path-gradient-renderer.browser.spec.js
+++ b/tests/path-gradient-renderer.browser.spec.js
@@ -1,0 +1,223 @@
+import { readFile } from 'node:fs/promises';
+
+import { expect, test } from '@playwright/test';
+
+test('adaptive gradients remain continuous and bounded on every path geometry', async ({ page }) => {
+  await page.route('http://fhs.test/**', async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+
+    if (pathname === '/gradient-fixture') {
+      await route.fulfill({
+        contentType: 'text/html',
+        body: `
+          <div id="fixture"></div>
+          <script type="importmap">
+            {
+              "imports": {
+                "lit": "/node_modules/lit/index.js",
+                "lit-html": "/node_modules/lit-html/lit-html.js",
+                "lit-html/": "/node_modules/lit-html/",
+                "lit-element/": "/node_modules/lit-element/",
+                "@lit/reactive-element": "/node_modules/@lit/reactive-element/reactive-element.js",
+                "@lit/reactive-element/": "/node_modules/@lit/reactive-element/"
+              }
+            }
+          </script>
+          <script type="module">
+            import { render, svg } from 'lit';
+            import {
+              buildArcPathDefinition,
+              buildInfinityPathDefinition,
+              buildLinePathDefinition,
+              buildRectanglePathDefinition,
+              buildSpiralPathDefinition,
+              buildWavePathDefinition,
+            } from '/src/path-generators.js';
+            import PathGeometry from '/src/path-geometry.js';
+            import { buildAdaptivePathGradient, renderAdaptivePathGradient } from '/src/path-gradient-renderer.js';
+
+            const definitions = [
+              buildArcPathDefinition({
+                cx: 50, cy: 50, radiusX: 38, radiusY: 38,
+                startAngle: 0, arcDegrees: 270,
+              }),
+              buildLinePathDefinition({ x1: 10, y1: 50, x2: 90, y2: 50 }),
+              buildRectanglePathDefinition({
+                x: 12, y: 12, width: 76, height: 76,
+                radiusTopLeft: 8, radiusTopRight: 8,
+                radiusBottomRight: 8, radiusBottomLeft: 8,
+                start: 'top', direction: 'clockwise',
+              }),
+              buildWavePathDefinition({
+                x1: 10, y1: 50, x2: 90, y2: 50,
+                waves: 2, amplitude: 18,
+              }),
+              buildSpiralPathDefinition({
+                cx: 50, cy: 50, radiusInner: 6, radiusOuter: 42,
+                startAngle: -90, degrees: 720, points: 48,
+              }),
+              buildInfinityPathDefinition({
+                cx: 50, cy: 50, radiusX: 42, radiusY: 27,
+              }),
+            ];
+            const positions = definitions.map((definition, index) => ({
+              x: 10 + (index % 3) * 110,
+              y: 10 + Math.floor(index / 3) * 110,
+            }));
+            const config = {
+              mode: 'full',
+              range: { start: 0, end: 75 },
+              colorStops: [
+                { progress: 0, color: '#ef4444' },
+                { progress: 35, color: '#facc15' },
+                { progress: 70, color: '#22c55e' },
+                { progress: 100, color: '#3b82f6' },
+              ],
+              width: 9,
+              startCap: 'round',
+              endCap: 'round',
+              maxSegmentLength: 6,
+              minSegmentLength: 1,
+              maxTangentAngle: 8,
+              maxSegments: 96,
+              overlap: 0.5,
+            };
+            const layer = {
+              opacity: 0.72,
+              fillOpacity: 1,
+              strokeOpacity: 1,
+              border: { color: '#111827', width: 0 },
+            };
+
+            render(svg\`
+              <svg id="gradient-showcase" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 340 230" width="680" height="460">
+                \${definitions.map((definition, index) => svg\`
+                  <g class="shape" data-index=\${index} transform="translate(\${positions[index].x} \${positions[index].y})">
+                    <path class="master" d=\${definition.d} pathLength="100" fill="none" stroke="transparent"></path>
+                    <g class="paint"></g>
+                  </g>
+                \`)}
+              </svg>
+            \`, document.querySelector('#fixture'));
+
+            const buildStarted = performance.now();
+            const gradients = definitions.map((definition, index) => {
+              const geometry = new PathGeometry(() => {});
+              geometry.setPathDefinition(definition);
+              geometry.bindPathElement(document.querySelector(\`.shape[data-index="\${index}"] .master\`));
+              return buildAdaptivePathGradient(geometry, config);
+            });
+            const buildDuration = performance.now() - buildStarted;
+            const renderStarted = performance.now();
+
+            gradients.forEach((gradient, index) => {
+              render(
+                renderAdaptivePathGradient(definitions[index], gradient, layer, \`gradient-\${index}\`, 'path-gradient'),
+                document.querySelector(\`.shape[data-index="\${index}"] .paint\`),
+              );
+            });
+
+            const renderDuration = performance.now() - renderStarted;
+            const frameStarted = performance.now();
+            await new Promise((resolve) => requestAnimationFrame(resolve));
+            const frameDuration = performance.now() - frameStarted;
+
+            window.gradientFixture = {
+              definitions,
+              gradients,
+              positions,
+              metrics: {
+                buildDuration,
+                renderDuration,
+                frameDuration,
+                nodeCount: document.querySelectorAll('#gradient-showcase *').length,
+                segmentCounts: gradients.map((gradient) => gradient.ranges.length),
+              },
+            };
+          </script>
+        `,
+      });
+      return;
+    }
+
+    const source = await readFile(new URL(`..${pathname}`, import.meta.url), 'utf8');
+
+    if (pathname === '/src/path-gradient-renderer.js') {
+      const browserColorInterpolation = `
+        const Colors = {
+          calculateStrokeColor(progress, colorStops) {
+            const stops = colorStops.colors;
+            if (progress <= stops[0].value) return stops[0].color;
+            if (progress >= stops[stops.length - 1].value) return stops[stops.length - 1].color;
+            const endIndex = stops.findIndex((stop) => progress < stop.value);
+            const start = stops[endIndex - 1];
+            const end = stops[endIndex];
+            const ratio = (progress - start.value) / (end.value - start.value);
+            const channels = [1, 3, 5].map((offset) => Math.floor(
+              Number.parseInt(start.color.slice(offset, offset + 2), 16) * (1 - ratio)
+              + Number.parseInt(end.color.slice(offset, offset + 2), 16) * ratio,
+            ));
+            return \`rgb(\${channels.join(',')})\`;
+          },
+        };
+      `;
+      await route.fulfill({
+        contentType: 'text/javascript',
+        body: source.replace("import Colors from './colors.js';", browserColorInterpolation),
+      });
+      return;
+    }
+
+    await route.fulfill({ contentType: 'text/javascript', body: source });
+  });
+
+  await page.goto('http://fhs.test/gradient-fixture');
+  await page.waitForFunction(() => window.gradientFixture !== undefined);
+
+  const result = await page.evaluate(async () => {
+    const { gradients, positions, metrics } = window.gradientFixture;
+    const sourceSvg = document.querySelector('#gradient-showcase');
+    const image = new Image();
+    const loaded = new Promise((resolve, reject) => {
+      image.addEventListener('load', resolve, { once: true });
+      image.addEventListener('error', reject, { once: true });
+    });
+    image.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(sourceSvg.outerHTML)}`;
+    await loaded;
+
+    const canvas = document.createElement('canvas');
+    canvas.width = 340;
+    canvas.height = 230;
+    const context = canvas.getContext('2d');
+    context.fillStyle = '#ffffff';
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    context.drawImage(image, 0, 0, canvas.width, canvas.height);
+    const paintedSamples = [...document.querySelectorAll('.shape')].map((shape, index) => {
+      const master = shape.querySelector('.master');
+      const totalLength = master.getTotalLength();
+      return Array.from({ length: 73 }, (_, sampleIndex) => {
+        const point = master.getPointAtLength(((sampleIndex + 1) / 100) * totalLength);
+        const pixel = context.getImageData(Math.round(point.x + positions[index].x), Math.round(point.y + positions[index].y), 1, 1).data;
+        return pixel[0] < 245 || pixel[1] < 245 || pixel[2] < 245;
+      });
+    });
+    const infinityOrder = [...document.querySelectorAll('.shape[data-index="5"] .path-gradient__band__fill')]
+      .map((range) => Number(range.dataset.pathRange.replace('gradient-', '')));
+
+    return {
+      metrics,
+      allSamplesPainted: paintedSamples.map((samples) => samples.every(Boolean)),
+      infinityOrder,
+      allRangeOpacitiesAreOne: gradients.every((gradient) => gradient.ranges.every((range) => range.opacity === 1)),
+    };
+  });
+
+  expect(result.allSamplesPainted).toEqual([true, true, true, true, true, true]);
+  expect(result.allRangeOpacitiesAreOne).toBe(true);
+  expect(result.infinityOrder).toEqual([...result.infinityOrder].sort((valueA, valueB) => valueA - valueB));
+  expect(Math.max(...result.metrics.segmentCounts)).toBeLessThanOrEqual(96);
+  expect(result.metrics.nodeCount).toBeLessThan(5000);
+  expect(result.metrics.buildDuration).toBeLessThan(250);
+  expect(result.metrics.renderDuration).toBeLessThan(100);
+  expect(result.metrics.frameDuration).toBeLessThan(100);
+});

--- a/tests/path-gradient-renderer.test.js
+++ b/tests/path-gradient-renderer.test.js
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildAdaptivePathGradient, renderAdaptivePathGradient } from '../src/path-gradient-renderer.js';
+
+const straightGeometry = {
+  getTotalLength: () => 200,
+  pointAtProgress: (progress) => ({ x: progress * 2, y: 20 }),
+};
+const baseConfig = {
+  mode: 'full',
+  range: { start: 0, end: 60 },
+  colorStops: [
+    { progress: 0, color: '#000000' },
+    { progress: 50, color: '#ff0000' },
+    { progress: 100, color: '#ffffff' },
+  ],
+  width: 8,
+  startCap: 'round',
+  endCap: 'round',
+  maxSegmentLength: 25,
+  minSegmentLength: 1,
+  maxTangentAngle: 12,
+  maxSegments: 96,
+  overlap: 0.5,
+};
+
+test('full gradient keeps a static color distribution behind the active reveal range', () => {
+  const first = buildAdaptivePathGradient(straightGeometry, baseConfig);
+  const second = buildAdaptivePathGradient(straightGeometry, {
+    ...baseConfig,
+    range: { start: 0, end: 80 },
+  });
+
+  assert.equal(first.ranges.length, 8);
+  assert.deepEqual(first.ranges, second.ranges);
+  assert.notDeepEqual(first.revealRange, second.revealRange);
+  assert.deepEqual(first.ranges.map((range) => range.opacity), Array(8).fill(1));
+  assert.equal(first.ranges[0].startCap, 'round');
+  assert.equal(first.ranges.at(-1).endCap, 'round');
+  assert.equal(first.ranges[0].gradient.startColor, '#000000');
+  assert.equal(first.ranges[3].gradient.endColor, '#ff0000ff');
+  assert.equal(first.ranges.at(-1).gradient.endColor, '#ffffff');
+});
+
+test('current gradient redistributes all configured colors over the active range', () => {
+  const gradient = buildAdaptivePathGradient(straightGeometry, {
+    ...baseConfig,
+    mode: 'current',
+    range: { start: 20, end: 60 },
+  });
+
+  assert.equal(gradient.ranges[0].start, 20);
+  assert.equal(gradient.ranges.at(-1).end, 60);
+  assert.equal(gradient.ranges[0].gradient.startColor, '#000000');
+  assert.equal(gradient.ranges.at(-1).gradient.endColor, '#ffffff');
+  assert.equal(gradient.ranges.some((range) => range.gradient.endColor === '#ff0000ff'), true);
+});
+
+test('adaptive splitting responds to curvature and never exceeds the configured DOM budget', () => {
+  const turningGeometry = {
+    getTotalLength: () => 100,
+    pointAtProgress: (progress) => {
+      const angle = (progress / 100) * Math.PI;
+      return { x: Math.cos(angle) * 50, y: Math.sin(angle) * 50 };
+    },
+  };
+  const gradient = buildAdaptivePathGradient(turningGeometry, {
+    ...baseConfig,
+    colorStops: [
+      { progress: 0, color: '#000000' },
+      { progress: 100, color: '#ffffff' },
+    ],
+    maxSegmentLength: 1000,
+    minSegmentLength: 0.001,
+    maxTangentAngle: 8,
+    maxSegments: 16,
+  });
+
+  assert.equal(gradient.ranges.length, 16);
+  assert.equal(gradient.ranges.every((range) => range.end > range.start), true);
+});
+
+test('renderer defines local gradients and reuses generic masked path bands', () => {
+  const gradient = buildAdaptivePathGradient(straightGeometry, baseConfig);
+  const layer = {
+    opacity: 0.4,
+    fillOpacity: 0.8,
+    strokeOpacity: 0.7,
+    border: { color: '#333333', width: 1 },
+  };
+  const pathDefinition = { d: 'M 0 20 L 200 20', signature: 'gradient-line' };
+  const rendered = renderAdaptivePathGradient(pathDefinition, gradient, layer, 'gradient-test', 'path-gradient');
+  const gradientDefinitions = rendered.values[1];
+  const bands = rendered.values[3];
+
+  assert.equal(gradientDefinitions.length, gradient.ranges.length);
+  assert.equal(bands.values[1], layer.opacity);
+  assert.equal(bands.values[5].at(-1).values[3].values[5], '10 100');
+  assert.equal(bands.values[5].at(-1).values[3].values[6], -50);
+});
+
+test('normalized reveal clipping does not use a spatial mask at path crossings', () => {
+  const gradient = buildAdaptivePathGradient(straightGeometry, {
+    ...baseConfig,
+    range: { start: 20, end: 60 },
+  });
+  const layer = {
+    opacity: 1,
+    fillOpacity: 1,
+    strokeOpacity: 1,
+    border: { color: '#333333', width: 0 },
+  };
+  const rendered = renderAdaptivePathGradient({ d: 'M 0 20 L 200 20' }, gradient, layer, 'crossing', 'path-gradient');
+  const bands = rendered.values[3];
+  const visibleFills = bands.values[5];
+
+  assert.equal(rendered.strings.join('').includes('reveal-mask'), false);
+  assert.equal(visibleFills[0].values[3].values[6], -20);
+  assert.equal(visibleFills.at(-1).values[3].values[5], '10 100');
+  assert.equal(visibleFills.at(-1).values[3].values[6], -50);
+});


### PR DESCRIPTION
## Summary
- add adaptive full-range and current-value gradients for arbitrary measured paths
- reuse the generic cap, border, transparency, and normalized range renderer
- clip reveal ranges in normalized path space so closed and self-intersecting paths remain correct
- bound gradient detail by visible segment length, curvature, minimum detail, and a hard DOM budget

## Verification
- npm run build: 269 tests, lint, and rollup pass
- npm run test:browser: 9 browser tests pass
- visual Chromium coverage includes arc, line, rectangle, wave, spiral, and infinity paths
- benchmark contract: at most 96 gradient segments per path, fewer than 5000 DOM nodes for six paths, render/frame below 100 ms, initial six-path geometry build below 250 ms

Closes #579