### PR TITLE
Horseshoe V3: add measured path scale features

### DIFF
--- a/src/path-feature-layout.js
+++ b/src/path-feature-layout.js
@@ -1,0 +1,124 @@
+/**
+ * Places ticks, labels, badges, and directional markers around one measured
+ * centerline. Every coordinate is derived from normalized progress plus the
+ * browser-measured point, tangent, and normal contract; no path shape is known
+ * or reconstructed here. Rotation and flips have already been applied to that
+ * geometry. Features receive final coordinates so labels never inherit a path
+ * transform and therefore remain readable.
+ *
+ * @param {PathGeometry} pathGeometry - Bound browser-measured path geometry.
+ * @param {object} config - Complete normalized feature layout configuration.
+ * @returns {object} Final renderer-ready feature coordinates and guide paths.
+ */
+export function buildPathFeatureLayout(pathGeometry, config) {
+  const pathDefinition = pathGeometry.getPathDefinition();
+  const pathLength = pathGeometry.getTotalLength();
+
+  // A closed path has one physical seam. Progress 100 is normalized to zero,
+  // then later duplicates at that position are removed in declaration order.
+  const normalizedTicks = config.ticks
+    .map((tick) => ({ ...tick, progress: pathDefinition.closed && tick.progress === 100 ? 0 : tick.progress }))
+    .filter((tick, index, ticks) => !pathDefinition.closed || tick.progress !== 0 || ticks.findIndex((candidate) => candidate.progress === 0) === index);
+  const ticks = normalizedTicks.map((tick) => {
+    const point = pathGeometry.pointAtProgress(tick.progress);
+    const normal = pathGeometry.normalAtProgress(tick.progress, tick.side);
+    const x1 = point.x + normal.x * tick.offset;
+    const y1 = point.y + normal.y * tick.offset;
+
+    return {
+      ...tick,
+      x1,
+      y1,
+      x2: x1 + normal.x * tick.length,
+      y2: y1 + normal.y * tick.length,
+    };
+  });
+
+  const normalizedLabels = config.labels
+    .map((label) => ({ ...label, progress: pathDefinition.closed && label.progress === 100 ? 0 : label.progress }))
+    .filter((label, index, labels) => !pathDefinition.closed || label.progress !== 0 || labels.findIndex((candidate) => candidate.progress === 0) === index);
+  const labels = normalizedLabels.map((label) => {
+    const point = pathGeometry.pointAtProgress(label.progress);
+    const tangent = pathGeometry.tangentAtProgress(label.progress);
+    const normal = pathGeometry.normalAtProgress(label.progress, label.side);
+    const x = point.x + normal.x * label.offset;
+    const y = point.y + normal.y * label.offset;
+    const tangentRotation = Math.atan2(tangent.y, tangent.x) * 180 / Math.PI;
+    let guidePath = '';
+    let guideStartOffset = 50;
+
+    if (label.orientation === 'path') {
+      const halfProgressLength = (label.length / pathLength) * 50;
+      const guideStart = label.progress - halfProgressLength;
+      const guideEnd = label.progress + halfProgressLength;
+      const guidePoints = Array.from({ length: label.samples }, (_, sampleIndex) => {
+        const unwrappedProgress = guideStart + (sampleIndex / (label.samples - 1)) * (guideEnd - guideStart);
+        const sampleProgress = pathDefinition.closed ? (unwrappedProgress + 100) % 100 : Math.min(100, Math.max(0, unwrappedProgress));
+        const pathPoint = pathGeometry.pointAtProgress(sampleProgress);
+        const sampleTangent = pathGeometry.tangentAtProgress(sampleProgress);
+        const sampleNormal = pathGeometry.normalAtProgress(sampleProgress, label.side);
+        const extensionLength = pathDefinition.closed ? 0 : (unwrappedProgress - sampleProgress) / 100 * pathLength;
+        const samplePoint = {
+          x: pathPoint.x + sampleTangent.x * extensionLength,
+          y: pathPoint.y + sampleTangent.y * extensionLength,
+        };
+
+        return {
+          x: samplePoint.x + sampleNormal.x * label.offset,
+          y: samplePoint.y + sampleNormal.y * label.offset,
+        };
+      });
+      const reverseGuide = tangent.x < 0;
+      const orderedGuidePoints = reverseGuide ? [...guidePoints].reverse() : guidePoints;
+
+      guidePath = orderedGuidePoints.map((guidePoint, index) => `${index === 0 ? 'M' : 'L'} ${guidePoint.x} ${guidePoint.y}`).join(' ');
+      guideStartOffset = 50;
+    }
+
+    return {
+      ...label,
+      x,
+      y,
+      tangentRotation,
+      guidePath,
+      guideStartOffset,
+      badge: {
+        ...label.badge,
+        x,
+        y,
+        rotation: label.orientation === 'path' ? tangentRotation : 0,
+      },
+    };
+  });
+
+  const normalizedMarkers = config.markers
+    .map((marker) => ({ ...marker, progress: pathDefinition.closed && marker.progress === 100 ? 0 : marker.progress }))
+    .filter((marker, index, markers) => !pathDefinition.closed || marker.progress !== 0 || markers.findIndex((candidate) => candidate.progress === 0) === index);
+  const markers = normalizedMarkers.map((marker) => {
+    const point = pathGeometry.pointAtProgress(marker.progress);
+    const pathTangent = pathGeometry.tangentAtProgress(marker.progress);
+    const normal = pathGeometry.normalAtProgress(marker.progress, marker.side);
+    const direction = marker.direction === 'forward' ? 1 : -1;
+    const tangent = { x: pathTangent.x * direction, y: pathTangent.y * direction };
+    const x = point.x + normal.x * marker.offset;
+    const y = point.y + normal.y * marker.offset;
+    const nose = { x: x + tangent.x * marker.length / 2, y: y + tangent.y * marker.length / 2 };
+    const tail = { x: x - tangent.x * marker.length / 2, y: y - tangent.y * marker.length / 2 };
+
+    return {
+      ...marker,
+      x,
+      y,
+      rotation: Math.atan2(tangent.y, tangent.x) * 180 / Math.PI,
+      points: [
+        nose,
+        { x: tail.x + normal.x * marker.width / 2, y: tail.y + normal.y * marker.width / 2 },
+        { x: tail.x - normal.x * marker.width / 2, y: tail.y - normal.y * marker.width / 2 },
+      ],
+    };
+  });
+
+  return { ticks, labels, markers };
+}
+
+export default buildPathFeatureLayout;

--- a/src/path-feature-renderer.js
+++ b/src/path-feature-renderer.js
@@ -1,0 +1,118 @@
+import { nothing, svg } from 'lit';
+import { styleMap } from 'lit/directives/style-map.js';
+
+/**
+ * Renders final path feature coordinates without reading or deriving geometry.
+ * Badge layers precede labels, while markers remain independently styleable
+ * above the static scale annotations.
+ *
+ * @param {object} featureLayout - Renderer-ready output from buildPathFeatureLayout().
+ * @param {string} featureId - Stable DOM namespace for label guide paths.
+ * @returns {TemplateResult} Tick, badge, label, and marker SVG layers.
+ */
+export function renderPathFeatures(featureLayout, featureId) {
+  return svg`
+    <g class="path-features" pointer-events="none">
+      <g class="path-features__ticks">
+        ${featureLayout.ticks.map((tick) => tick.shape === 'circle' ? svg`
+          <circle
+            class="path-features__tick path-features__tick--${tick.layer}"
+            data-feature-id=${tick.id}
+            cx=${tick.x1}
+            cy=${tick.y1}
+            r=${tick.radius}
+            style=${styleMap(tick.styles)}
+          ></circle>
+        ` : svg`
+          <line
+            class="path-features__tick path-features__tick--${tick.layer}"
+            data-feature-id=${tick.id}
+            x1=${tick.x1}
+            y1=${tick.y1}
+            x2=${tick.x2}
+            y2=${tick.y2}
+            style=${styleMap(tick.styles)}
+          ></line>
+        `)}
+      </g>
+
+      <g class="path-features__badges">
+        ${featureLayout.labels.map((label) => !label.badge.visible ? nothing : label.badge.shape === 'circle' ? svg`
+          <circle
+            class="path-features__badge"
+            data-feature-id=${label.id}
+            cx=${label.badge.x}
+            cy=${label.badge.y}
+            r=${label.badge.radius}
+            style=${styleMap(label.badge.styles)}
+          ></circle>
+        ` : svg`
+          <rect
+            class="path-features__badge"
+            data-feature-id=${label.id}
+            x=${label.badge.x - label.badge.width / 2}
+            y=${label.badge.y - label.badge.height / 2}
+            width=${label.badge.width}
+            height=${label.badge.height}
+            rx=${label.badge.radius}
+            ry=${label.badge.radius}
+            transform="rotate(${label.badge.rotation} ${label.badge.x} ${label.badge.y})"
+            style=${styleMap(label.badge.styles)}
+          ></rect>
+        `)}
+      </g>
+
+      <g class="path-features__labels">
+        ${featureLayout.labels.map((label, index) => label.orientation === 'path' ? svg`
+          <path
+            id="${featureId}-label-guide-${index}"
+            class="path-features__label-guide"
+            d=${label.guidePath}
+            fill="none"
+            stroke="none"
+          ></path>
+          <text class="path-features__label" data-feature-id=${label.id} style=${styleMap(label.styles)}>
+            <textPath
+              href="#${featureId}-label-guide-${index}"
+              startOffset="${label.guideStartOffset}%"
+              text-anchor="middle"
+            >${label.text}</textPath>
+          </text>
+        ` : svg`
+          <text
+            class="path-features__label"
+            data-feature-id=${label.id}
+            x=${label.x}
+            y=${label.y}
+            text-anchor="middle"
+            dominant-baseline="central"
+            style=${styleMap(label.styles)}
+          >${label.text}</text>
+        `)}
+      </g>
+
+      <g class="path-features__markers">
+        ${featureLayout.markers.map((marker) => marker.shape === 'circle' ? svg`
+          <circle
+            class="path-features__marker"
+            data-feature-id=${marker.id}
+            cx=${marker.x}
+            cy=${marker.y}
+            r=${marker.radius}
+            style=${styleMap(marker.styles)}
+          ></circle>
+        ` : svg`
+          <polygon
+            class="path-features__marker"
+            data-feature-id=${marker.id}
+            points=${marker.points.map((point) => `${point.x},${point.y}`).join(' ')}
+            data-rotation=${marker.rotation}
+            style=${styleMap(marker.styles)}
+          ></polygon>
+        `)}
+      </g>
+    </g>
+  `;
+}
+
+export default renderPathFeatures;

--- a/tests/path-feature-layout.browser.spec.js
+++ b/tests/path-feature-layout.browser.spec.js
@@ -1,0 +1,171 @@
+import { readFile } from 'node:fs/promises';
+
+import { expect, test } from '@playwright/test';
+
+test('path features follow measured geometry on every supported path shape', async ({ page }) => {
+  const pageErrors = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+
+  await page.route('http://fhs.test/**', async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+
+    if (pathname === '/path-feature-fixture') {
+      await route.fulfill({
+        contentType: 'text/html',
+        body: `
+          <div id="fixture"></div>
+          <script type="importmap">
+            {
+              "imports": {
+                "lit": "/node_modules/lit/index.js",
+                "lit/": "/node_modules/lit/",
+                "lit-html": "/node_modules/lit-html/lit-html.js",
+                "lit-html/": "/node_modules/lit-html/",
+                "lit-element/": "/node_modules/lit-element/",
+                "@lit/reactive-element": "/node_modules/@lit/reactive-element/reactive-element.js",
+                "@lit/reactive-element/": "/node_modules/@lit/reactive-element/"
+              }
+            }
+          </script>
+          <script type="module">
+            import { render, svg } from 'lit';
+            import {
+              buildArcPathDefinition,
+              buildInfinityPathDefinition,
+              buildLinePathDefinition,
+              buildRectanglePathDefinition,
+              buildSpiralPathDefinition,
+              buildWavePathDefinition,
+            } from '/src/path-generators.js';
+            import PathGeometry from '/src/path-geometry.js';
+            import { buildPathFeatureLayout } from '/src/path-feature-layout.js';
+            import { renderPathFeatures } from '/src/path-feature-renderer.js';
+
+            const definitions = [
+              buildArcPathDefinition({ cx: 50, cy: 50, radiusX: 35, radiusY: 35, startAngle: -135, arcDegrees: 270 }),
+              buildLinePathDefinition({ x1: 10, y1: 50, x2: 90, y2: 50 }),
+              buildRectanglePathDefinition({
+                x: 13, y: 13, width: 74, height: 74,
+                radiusTopLeft: 9, radiusTopRight: 9, radiusBottomRight: 9, radiusBottomLeft: 9,
+                start: 'top', direction: 'clockwise',
+              }),
+              buildWavePathDefinition({ x1: 10, y1: 50, x2: 90, y2: 50, waves: 2, amplitude: 15 }),
+              buildSpiralPathDefinition({ cx: 50, cy: 50, radiusInner: 6, radiusOuter: 40, startAngle: -90, degrees: 720, points: 48 }),
+              buildInfinityPathDefinition({ cx: 50, cy: 50, radiusX: 40, radiusY: 25 }),
+            ];
+            const positions = definitions.map((definition, index) => ({
+              x: 10 + (index % 3) * 115,
+              y: 10 + Math.floor(index / 3) * 125,
+            }));
+            const featureConfig = {
+              ticks: [0, 12.5, 25, 50, 75, 100].map((progress, index) => ({
+                id: \`tick-\${index}\`, layer: index % 2 === 0 ? 'major' : 'minor', progress,
+                side: 'left', offset: 3, length: index % 2 === 0 ? 7 : 4,
+                shape: index % 2 === 0 ? 'line' : 'circle', radius: 1.5,
+                styles: { stroke: '#334155', fill: '#334155', 'stroke-width': 1 },
+              })),
+              labels: [
+                {
+                  id: 'horizontal', progress: 0, side: 'left', offset: 15, text: 'Start', orientation: 'horizontal', length: 32, samples: 9,
+                  styles: { fill: '#0f172a', 'font-size': '6px', 'text-anchor': 'middle', 'dominant-baseline': 'central' },
+                  badge: { visible: true, shape: 'circle', radius: 6, width: 0, height: 0, styles: { fill: '#e2e8f0' } },
+                },
+                {
+                  id: 'path', progress: 50, side: 'right', offset: 13, text: 'Half', orientation: 'path', length: 34, samples: 11,
+                  styles: { fill: '#0f172a', 'font-size': '6px', 'text-anchor': 'middle', 'dominant-baseline': 'central' },
+                  badge: { visible: true, shape: 'capsule', radius: 3, width: 24, height: 9, styles: { fill: '#fef3c7' } },
+                },
+              ],
+              markers: [
+                { id: 'forward', progress: 0, side: 'right', offset: 6, direction: 'forward', shape: 'triangle', length: 9, width: 6, radius: 0, styles: { fill: '#dc2626' } },
+                { id: 'crossing', progress: 50, side: 'right', offset: 6, direction: 'backward', shape: 'circle', length: 9, width: 6, radius: 2.5, styles: { fill: '#2563eb' } },
+                { id: 'seam', progress: 100, side: 'right', offset: 6, direction: 'forward', shape: 'triangle', length: 9, width: 6, radius: 0, styles: { fill: '#16a34a' } },
+              ],
+            };
+
+            render(svg\`
+              <svg id="path-feature-showcase" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 350 250" width="700" height="500">
+                <rect width="350" height="250" fill="white"></rect>
+                \${definitions.map((definition, index) => svg\`
+                  <g class="shape" data-index=\${index} transform="translate(\${positions[index].x} \${positions[index].y})">
+                    <path class="master" d=\${definition.d} fill="none" stroke="#94a3b8" stroke-width="5"></path>
+                    <g class="features"></g>
+                  </g>
+                \`)}
+              </svg>
+            \`, document.querySelector('#fixture'));
+
+            const geometries = definitions.map((definition, index) => {
+              const geometry = new PathGeometry(() => {});
+              geometry.setPathDefinition(definition);
+              geometry.bindPathElement(document.querySelector(\`.shape[data-index="\${index}"] .master\`));
+              return geometry;
+            });
+            const layouts = geometries.map((geometry) => buildPathFeatureLayout(geometry, featureConfig));
+            const repeatedLayouts = geometries.map((geometry) => buildPathFeatureLayout(geometry, featureConfig));
+
+            layouts.forEach((layout, index) => {
+              render(renderPathFeatures(layout, \`shape-\${index}\`), document.querySelector(\`.shape[data-index="\${index}"] .features\`));
+            });
+
+            window.pathFeatureFixture = { definitions, geometries, layouts, repeatedLayouts };
+          </script>
+        `,
+      });
+      return;
+    }
+
+    const source = await readFile(new URL(`..${pathname}`, import.meta.url));
+    await route.fulfill({ contentType: 'text/javascript', body: source });
+  });
+
+  await page.goto('http://fhs.test/path-feature-fixture');
+  await page.waitForTimeout(100);
+  expect(pageErrors).toEqual([]);
+  await expect.poll(() => page.evaluate(() => window.pathFeatureFixture !== undefined)).toBe(true);
+
+  const result = await page.evaluate(() => {
+    const { definitions, geometries, layouts, repeatedLayouts } = window.pathFeatureFixture;
+
+    return layouts.map((layout, index) => {
+      const geometry = geometries[index];
+      const sourcePoint = geometry.pointAtProgress(25);
+      const sourceNormal = geometry.normalAtProgress(25, 'left');
+      const tick = layout.ticks.find((candidate) => candidate.progress === 25);
+      const offsetVector = { x: tick.x1 - sourcePoint.x, y: tick.y1 - sourcePoint.y };
+      const shape = document.querySelector(`.shape[data-index="${index}"]`);
+
+      return {
+        closed: definitions[index].closed,
+        tickCount: layout.ticks.length,
+        markerCount: layout.markers.length,
+        labelCount: layout.labels.length,
+        finite: [...layout.ticks, ...layout.labels, ...layout.markers].every((item) => (
+          Number.isFinite(item.x ?? item.x1) && Number.isFinite(item.y ?? item.y1)
+        )),
+        normalOffset: offsetVector.x * sourceNormal.x + offsetVector.y * sourceNormal.y,
+        repeatedLayoutMatches: JSON.stringify(layout) === JSON.stringify(repeatedLayouts[index]),
+        horizontalTransform: shape.querySelector('.path-features__label[data-feature-id="horizontal"]').getAttribute('transform'),
+        guideLength: shape.querySelector('.path-features__label-guide').getTotalLength(),
+        visibleBadgeCount: shape.querySelectorAll('.path-features__badge').length,
+      };
+    });
+  });
+
+  expect(result).toHaveLength(6);
+  result.forEach((shape) => {
+    expect(shape.tickCount).toBe(shape.closed ? 5 : 6);
+    expect(shape.markerCount).toBe(shape.closed ? 2 : 3);
+    expect(shape.labelCount).toBe(2);
+    expect(shape.finite).toBe(true);
+    expect(shape.normalOffset).toBeCloseTo(3, 5);
+    expect(shape.repeatedLayoutMatches).toBe(true);
+    expect(shape.horizontalTransform).toBeNull();
+    expect(shape.guideLength).toBeGreaterThan(0);
+    expect(shape.visibleBadgeCount).toBe(2);
+  });
+
+  const infinity = result[5];
+  expect(infinity.closed).toBe(true);
+  expect(infinity.markerCount).toBe(2);
+});

--- a/tests/path-feature-layout.test.js
+++ b/tests/path-feature-layout.test.js
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildPathFeatureLayout } from '../src/path-feature-layout.js';
+import { renderPathFeatures } from '../src/path-feature-renderer.js';
+
+function createMeasuredLineGeometry(closed = false) {
+  return {
+    getPathDefinition: () => ({ closed }),
+    getTotalLength: () => 100,
+    pointAtProgress: (progress) => ({ x: progress, y: 50 }),
+    tangentAtProgress: () => ({ x: 1, y: 0 }),
+    normalAtProgress: (_progress, side) => side === 'left' ? { x: 0, y: -1 } : { x: 0, y: 1 },
+  };
+}
+
+const featureConfig = {
+  ticks: [
+    { id: 'major-25', layer: 'major', progress: 25, side: 'left', offset: 2, length: 8, shape: 'line', radius: 0, styles: { stroke: 'black' } },
+    { id: 'minor-75', layer: 'minor', progress: 75, side: 'right', offset: 3, length: 0, shape: 'circle', radius: 2, styles: { fill: 'black' } },
+  ],
+  labels: [
+    {
+      id: 'horizontal', progress: 25, side: 'left', offset: 14, text: '25', orientation: 'horizontal', length: 30, samples: 7, styles: { fill: 'black' },
+      badge: { visible: true, shape: 'circle', radius: 5, width: 0, height: 0, styles: { fill: 'white' } },
+    },
+    {
+      id: 'path', progress: 75, side: 'right', offset: 14, text: '75', orientation: 'path', length: 30, samples: 7, styles: { fill: 'black' },
+      badge: { visible: true, shape: 'capsule', radius: 3, width: 18, height: 8, styles: { fill: 'white' } },
+    },
+  ],
+  markers: [
+    { id: 'forward', progress: 50, side: 'left', offset: 5, direction: 'forward', shape: 'triangle', length: 10, width: 6, radius: 0, styles: { fill: 'red' } },
+    { id: 'reverse', progress: 50, side: 'right', offset: 5, direction: 'backward', shape: 'circle', length: 10, width: 6, radius: 3, styles: { fill: 'blue' } },
+  ],
+};
+
+test('ticks, labels, badges, and markers use measured points and normals', () => {
+  const layout = buildPathFeatureLayout(createMeasuredLineGeometry(), featureConfig);
+
+  assert.deepEqual(layout.ticks.map((tick) => ({ id: tick.id, x1: tick.x1, y1: tick.y1, x2: tick.x2, y2: tick.y2 })), [
+    { id: 'major-25', x1: 25, y1: 48, x2: 25, y2: 40 },
+    { id: 'minor-75', x1: 75, y1: 53, x2: 75, y2: 53 },
+  ]);
+  assert.deepEqual(layout.labels.map((label) => ({ id: label.id, x: label.x, y: label.y })), [
+    { id: 'horizontal', x: 25, y: 36 },
+    { id: 'path', x: 75, y: 64 },
+  ]);
+  assert.equal(layout.labels[1].guidePath, 'M 60 64 L 65 64 L 70 64 L 75 64 L 80 64 L 85 64 L 90 64');
+  assert.deepEqual(layout.markers[0].points, [
+    { x: 55, y: 45 },
+    { x: 45, y: 42 },
+    { x: 45, y: 48 },
+  ]);
+  assert.equal(layout.markers[1].rotation, -180);
+});
+
+test('feature positions use transformed geometry while horizontal labels remain untransformed', () => {
+  const transformedGeometry = {
+    getPathDefinition: () => ({ closed: false }),
+    getTotalLength: () => 100,
+    pointAtProgress: (progress) => ({ x: 50, y: 100 - progress }),
+    tangentAtProgress: () => ({ x: 0, y: -1 }),
+    normalAtProgress: (_progress, side) => side === 'left' ? { x: -1, y: 0 } : { x: 1, y: 0 },
+  };
+  const layout = buildPathFeatureLayout(transformedGeometry, featureConfig);
+  const rendered = renderPathFeatures(layout, 'transformed');
+
+  assert.deepEqual({ x: layout.labels[0].x, y: layout.labels[0].y }, { x: 36, y: 75 });
+  assert.equal(layout.labels[0].tangentRotation, -90);
+  assert.doesNotMatch(rendered.strings.join(''), /path-features__label-horizontal[^>]*transform=/);
+});
+
+test('path labels remain centered at either end of an open path', () => {
+  const endpointConfig = {
+    ticks: [],
+    labels: [
+      { ...featureConfig.labels[1], id: 'start', progress: 0 },
+      { ...featureConfig.labels[1], id: 'end', progress: 100 },
+    ],
+    markers: [],
+  };
+  const layout = buildPathFeatureLayout(createMeasuredLineGeometry(), endpointConfig);
+
+  assert.match(layout.labels[0].guidePath, /^M -15 64 .* L 15 64$/);
+  assert.match(layout.labels[1].guidePath, /^M 85 64 .* L 115 64$/);
+  assert.deepEqual(layout.labels.map((label) => label.guideStartOffset), [50, 50]);
+});
+
+test('reversed path traversal reverses the local guide instead of transforming its text', () => {
+  const reversedGeometry = {
+    getPathDefinition: () => ({ closed: false }),
+    getTotalLength: () => 100,
+    pointAtProgress: (progress) => ({ x: 100 - progress, y: 50 }),
+    tangentAtProgress: () => ({ x: -1, y: 0 }),
+    normalAtProgress: (_progress, side) => side === 'left' ? { x: 0, y: 1 } : { x: 0, y: -1 },
+  };
+  const reversedConfig = {
+    ticks: [],
+    labels: [{ ...featureConfig.labels[1], progress: 75 }],
+    markers: [],
+  };
+  const layout = buildPathFeatureLayout(reversedGeometry, reversedConfig);
+  const rendered = renderPathFeatures(layout, 'reversed');
+
+  assert.equal(layout.labels[0].guidePath, 'M 10 36 L 15 36 L 20 36 L 25 36 L 30 36 L 35 36 L 40 36');
+  assert.equal(layout.labels[0].guideStartOffset, 50);
+  assert.doesNotMatch(rendered.strings.join(''), /scale\(-1/);
+});
+
+test('closed seams place progress zero once and wrap path-label guide geometry', () => {
+  const closedConfig = {
+    ticks: [
+      { ...featureConfig.ticks[0], id: 'zero', progress: 0 },
+      { ...featureConfig.ticks[0], id: 'hundred', progress: 100 },
+    ],
+    labels: [
+      { ...featureConfig.labels[1], id: 'zero-label', progress: 0 },
+      { ...featureConfig.labels[1], id: 'hundred-label', progress: 100 },
+    ],
+    markers: [
+      { ...featureConfig.markers[0], id: 'zero-marker', progress: 0 },
+      { ...featureConfig.markers[0], id: 'hundred-marker', progress: 100 },
+    ],
+  };
+  const layout = buildPathFeatureLayout(createMeasuredLineGeometry(true), closedConfig);
+
+  assert.equal(layout.ticks.length, 1);
+  assert.equal(layout.labels.length, 1);
+  assert.equal(layout.markers.length, 1);
+  assert.match(layout.labels[0].guidePath, /^M 85 64 L 90 64 L 95 64 L 0 64 L 5 64 L 10 64 L 15 64$/);
+  assert.equal(layout.labels[0].guideStartOffset, 50);
+});
+
+test('renderer consumes final feature coordinates without geometry input', () => {
+  const layout = buildPathFeatureLayout(createMeasuredLineGeometry(), featureConfig);
+  const rendered = renderPathFeatures(layout, 'features');
+  const source = rendered.strings.join('');
+
+  assert.match(source, /path-features__ticks/);
+  assert.match(source, /path-features__badges/);
+  assert.match(source, /path-features__labels/);
+  assert.match(source, /path-features__markers/);
+  assert.equal(rendered.values[0].length, 2);
+  assert.equal(rendered.values[1].length, 2);
+  assert.equal(rendered.values[2].length, 2);
+  assert.equal(rendered.values[3].length, 2);
+});


### PR DESCRIPTION
Closes #580

- places ticks, labels, badges, and markers through measured point/tangent/normal geometry
- keeps horizontal text readable without inheriting horseshoe rotate or flip transforms
- handles open endpoints, reversed traversal, closed seams, corners, and crossings
- adds unit and six-shape browser coverage

Validation: npm run build; npx playwright test --reporter=line