### PR TITLE
Horseshoe V3: add targeted path state animation

### DIFF
--- a/src/path-animator.js
+++ b/src/path-animator.js
@@ -1,0 +1,116 @@
+import { clamp } from './frontend_mods/common/number/clamp.ts';
+
+const PATH_ANIMATION_EASING = {
+  linear: (progress) => progress,
+  'ease-in': (progress) => progress ** 3,
+  'ease-out': (progress) => 1 - (1 - progress) ** 3,
+  'ease-in-out': (progress) => progress < 0.5 ? 4 * progress ** 3 : 1 - (-2 * progress + 2) ** 3 / 2,
+};
+
+/**
+ * Animates normalized state progress inside one explicitly bound state layer.
+ * Geometry and static visual layers are deliberately absent from this contract:
+ * the adapter supplies one targeted state updater after the master path has
+ * already been generated, rendered, bound, and measured.
+ */
+export default class PathStateAnimator {
+  /**
+   * Stores the complete internal animation contract.
+   *
+   * @param {object} config - Validated timing, scheduler, and state-layer update callbacks.
+   */
+  constructor(config) {
+    this.animation = config.animation;
+    this.requestFrame = config.requestFrame;
+    this.cancelFrame = config.cancelFrame;
+    this.updateStateLayer = config.updateStateLayer;
+    this.onComplete = config.onComplete;
+    this.currentProgress = config.initialProgress;
+    this.stateLayerElement = undefined;
+    this.frame = undefined;
+    this.startTime = undefined;
+    this.fromProgress = config.initialProgress;
+    this.toProgress = config.initialProgress;
+    this.animating = false;
+  }
+
+  /**
+   * Binds the mutable state-layer mount and paints its current progress. Static
+   * siblings remain owned by the normal renderer and are never passed here.
+   *
+   * @param {Element} stateLayerElement - Dedicated DOM mount for state-dependent path output.
+   */
+  bindStateLayer(stateLayerElement) {
+    this.stateLayerElement = stateLayerElement;
+    this.updateStateLayer(this.stateLayerElement, this.currentProgress);
+  }
+
+  /**
+   * Replaces any active transition and animates from the currently displayed
+   * progress, preventing an interrupted update from jumping back to its old source.
+   *
+   * @param {number} targetProgress - Validated normalized target in 0..100 path space.
+   */
+  animateTo(targetProgress) {
+    if (this.frame !== undefined) {
+      this.cancelFrame(this.frame);
+    }
+
+    this.frame = undefined;
+    this.startTime = undefined;
+    this.fromProgress = this.currentProgress;
+    this.toProgress = targetProgress;
+
+    if (!this.animation.enabled) {
+      this.currentProgress = this.toProgress;
+      this.animating = false;
+      this.updateStateLayer(this.stateLayerElement, this.currentProgress);
+      this.onComplete(this.currentProgress);
+      return;
+    }
+
+    this.animating = true;
+    const easing = PATH_ANIMATION_EASING[this.animation.easing];
+
+    // Only normalized progress changes per frame. The bound updater decides
+    // whether that means one dash change, segment visibility, or a state-only
+    // gradient rerender; it cannot invalidate the master geometry lifecycle.
+    const updateAnimationFrame = (timestamp) => {
+      if (this.startTime === undefined) {
+        this.startTime = timestamp;
+      }
+
+      const elapsed = timestamp - this.startTime;
+      const linearProgress = clamp(elapsed / this.animation.duration, 0, 1);
+      const easedProgress = easing(linearProgress);
+      this.currentProgress = this.fromProgress + (this.toProgress - this.fromProgress) * easedProgress;
+      this.updateStateLayer(this.stateLayerElement, this.currentProgress);
+
+      if (linearProgress < 1) {
+        this.frame = this.requestFrame(updateAnimationFrame);
+        return;
+      }
+
+      this.frame = undefined;
+      this.startTime = undefined;
+      this.animating = false;
+      this.onComplete(this.toProgress);
+    };
+
+    this.frame = this.requestFrame(updateAnimationFrame);
+  }
+
+  /**
+   * Cancels pending frame work while retaining the currently displayed progress.
+   * A later target therefore continues from the visible state.
+   */
+  stopAnimation() {
+    if (this.frame !== undefined) {
+      this.cancelFrame(this.frame);
+    }
+
+    this.frame = undefined;
+    this.startTime = undefined;
+    this.animating = false;
+  }
+}

--- a/src/path-gradient-renderer.js
+++ b/src/path-gradient-renderer.js
@@ -115,6 +115,25 @@ export function buildAdaptivePathGradient(pathGeometry, config) {
 }
 
 /**
+ * Moves the reveal over a previously built full-path gradient without sampling
+ * geometry or rebuilding its adaptive color ranges.
+ *
+ * @param {object} gradient - Existing full-path adaptive gradient.
+ * @param {object} range - New normalized visible start and end progress.
+ * @returns {object} The same gradient object with its reveal range updated.
+ */
+export function setFullPathGradientRevealRange(gradient, range) {
+  const revealLength = range.end - range.start;
+
+  gradient.revealRange.start = range.start;
+  gradient.revealRange.end = range.end;
+  gradient.revealRange.dash.array = [revealLength, 100];
+  gradient.revealRange.dash.offset = range.start === 0 ? 0 : -range.start;
+
+  return gradient;
+}
+
+/**
  * Renders adaptive gradient ranges through the same generic band, border, cap,
  * and transparency pipeline as solid ranges. Full gradients are clipped by a
  * normalized dash intersections so state-only updates do not rebuild colors

--- a/tests/path-animator.browser.spec.js
+++ b/tests/path-animator.browser.spec.js
@@ -1,0 +1,204 @@
+import { readFile } from 'node:fs/promises';
+
+import { expect, test } from '@playwright/test';
+
+test('state animation preserves measured geometry and every static path layer', async ({ page }) => {
+  const pageErrors = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+
+  await page.route('http://fhs.test/**', async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+
+    if (pathname === '/path-animation-fixture') {
+      await route.fulfill({
+        contentType: 'text/html',
+        body: `
+          <div id="fixture"></div>
+          <script type="importmap">
+            {
+              "imports": {
+                "lit": "/node_modules/lit/index.js",
+                "lit/": "/node_modules/lit/",
+                "lit-html": "/node_modules/lit-html/lit-html.js",
+                "lit-html/": "/node_modules/lit-html/",
+                "lit-element/": "/node_modules/lit-element/",
+                "@lit/reactive-element": "/node_modules/@lit/reactive-element/reactive-element.js",
+                "@lit/reactive-element/": "/node_modules/@lit/reactive-element/"
+              }
+            }
+          </script>
+          <script type="module">
+            import { render, svg } from 'lit';
+            import PathStateAnimator from '/src/path-animator.js';
+            import { buildPathFeatureLayout } from '/src/path-feature-layout.js';
+            import { renderPathFeatures } from '/src/path-feature-renderer.js';
+            import {
+              buildArcPathDefinition,
+              buildInfinityPathDefinition,
+              buildLinePathDefinition,
+              buildRectanglePathDefinition,
+              buildSpiralPathDefinition,
+              buildWavePathDefinition,
+            } from '/src/path-generators.js';
+            import PathGeometry from '/src/path-geometry.js';
+            import { renderNormalizedPathBands } from '/src/path-mask-renderer.js';
+
+            const definitions = [
+              buildArcPathDefinition({ cx: 50, cy: 50, radiusX: 35, radiusY: 35, startAngle: -135, arcDegrees: 270 }),
+              buildLinePathDefinition({ x1: 10, y1: 50, x2: 90, y2: 50 }),
+              buildRectanglePathDefinition({
+                x: 13, y: 13, width: 74, height: 74,
+                radiusTopLeft: 9, radiusTopRight: 9, radiusBottomRight: 9, radiusBottomLeft: 9,
+                start: 'top', direction: 'clockwise',
+              }),
+              buildWavePathDefinition({ x1: 10, y1: 50, x2: 90, y2: 50, waves: 2, amplitude: 15 }),
+              buildSpiralPathDefinition({ cx: 50, cy: 50, radiusInner: 6, radiusOuter: 40, startAngle: -90, degrees: 720, points: 48 }),
+              buildInfinityPathDefinition({ cx: 50, cy: 50, radiusX: 40, radiusY: 25 }),
+            ];
+            const positions = definitions.map((definition, index) => ({
+              x: 10 + (index % 3) * 110,
+              y: 10 + Math.floor(index / 3) * 110,
+            }));
+            const featureConfig = {
+              ticks: [
+                { id: 'tick', layer: 'major', progress: 50, side: 'left', offset: 3, length: 6, shape: 'line', radius: 0, styles: { stroke: '#0f172a' } },
+              ],
+              labels: [
+                {
+                  id: 'label', progress: 50, side: 'left', offset: 13, text: '50', orientation: 'horizontal', length: 24, samples: 7,
+                  styles: { fill: '#0f172a', 'font-size': '6px' },
+                  badge: { visible: false, shape: 'circle', radius: 0, width: 0, height: 0, styles: { fill: 'none' } },
+                },
+              ],
+              markers: [],
+            };
+            const stateLayerConfig = {
+              opacity: 0.75,
+              fillOpacity: 1,
+              strokeOpacity: 1,
+              border: { color: '#0f172a', width: 1 },
+            };
+
+            render(svg\`
+              <svg id="path-animation-showcase" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 330 220">
+                \${definitions.map((definition, index) => svg\`
+                  <g class="shape" data-index=\${index} transform="translate(\${positions[index].x} \${positions[index].y})">
+                    <path class="background" d=\${definition.d} fill="none" stroke="#cbd5e1" stroke-width="8"></path>
+                    <path class="master" d=\${definition.d} fill="none" stroke="transparent" stroke-width="0" visibility="hidden"></path>
+                    <g class="state"></g>
+                    <g class="features"></g>
+                  </g>
+                \`)}
+              </svg>
+            \`, document.querySelector('#fixture'));
+
+            const fixtures = definitions.map((definition, index) => {
+              const shape = document.querySelector(\`.shape[data-index="\${index}"]\`);
+              const master = shape.querySelector('.master');
+              const nativeGetTotalLength = master.getTotalLength.bind(master);
+              let measurementCount = 0;
+              master.getTotalLength = () => {
+                measurementCount += 1;
+                return nativeGetTotalLength();
+              };
+
+              const geometry = new PathGeometry(() => {});
+              geometry.setPathDefinition(definition);
+              geometry.bindPathElement(master);
+              render(renderPathFeatures(buildPathFeatureLayout(geometry, featureConfig), \`animation-feature-\${index}\`), shape.querySelector('.features'));
+
+              const stateLayer = shape.querySelector('.state');
+              const animator = new PathStateAnimator({
+                animation: { enabled: true, duration: 60, easing: 'linear' },
+                initialProgress: 20,
+                requestFrame: window.requestAnimationFrame.bind(window),
+                cancelFrame: window.cancelAnimationFrame.bind(window),
+                updateStateLayer: (element, progress) => {
+                  const range = {
+                    id: 'state', start: 0, end: progress, length: progress,
+                    color: '#2563eb', width: 6, opacity: 1,
+                    startCap: 'round', endCap: 'round',
+                    dash: { array: [progress, 100], offset: 0 },
+                  };
+                  render(
+                    renderNormalizedPathBands(definition, [range], stateLayerConfig, \`animation-state-\${index}\`, 'path-animation-state'),
+                    element,
+                  );
+                },
+                onComplete: () => {},
+              });
+              animator.bindStateLayer(stateLayer);
+
+              return {
+                animator,
+                geometry,
+                getMeasurementCount: () => measurementCount,
+                nodes: {
+                  master,
+                  background: shape.querySelector('.background'),
+                  features: shape.querySelector('.path-features'),
+                  stateBody: shape.querySelector('.path-animation-state__fill-stroke__body'),
+                },
+              };
+            });
+
+            fixtures.forEach((fixture) => fixture.animator.animateTo(80));
+            window.pathAnimationFixture = { fixtures };
+          </script>
+        `,
+      });
+      return;
+    }
+
+    const source = await readFile(new URL(`..${pathname}`, import.meta.url), 'utf8');
+
+    if (pathname === '/src/path-animator.js') {
+      await route.fulfill({
+        contentType: 'text/javascript',
+        body: source.replace(
+          "import { clamp } from './frontend_mods/common/number/clamp.ts';",
+          'const clamp = (value, lower, upper) => Math.min(upper, Math.max(lower, value));',
+        ),
+      });
+      return;
+    }
+
+    await route.fulfill({ contentType: 'text/javascript', body: source });
+  });
+
+  await page.goto('http://fhs.test/path-animation-fixture');
+  await page.waitForTimeout(100);
+  expect(pageErrors).toEqual([]);
+  await expect.poll(() => page.evaluate(() => window.pathAnimationFixture?.fixtures.every((fixture) => !fixture.animator.animating))).toBe(true);
+
+  await page.evaluate(() => window.pathAnimationFixture.fixtures.forEach((fixture) => fixture.animator.animateTo(35)));
+  await expect.poll(() => page.evaluate(() => window.pathAnimationFixture.fixtures.every((fixture) => !fixture.animator.animating))).toBe(true);
+
+  const result = await page.evaluate(() => window.pathAnimationFixture.fixtures.map((fixture, index) => {
+    const shape = document.querySelector(`.shape[data-index="${index}"]`);
+    const stateBody = shape.querySelector('.path-animation-state__fill-stroke__body');
+
+    return {
+      progress: fixture.animator.currentProgress,
+      measurementCount: fixture.getMeasurementCount(),
+      masterPreserved: fixture.nodes.master === shape.querySelector('.master'),
+      backgroundPreserved: fixture.nodes.background === shape.querySelector('.background'),
+      featuresPreserved: fixture.nodes.features === shape.querySelector('.path-features'),
+      stateBodyPreserved: fixture.nodes.stateBody === stateBody,
+      dashArray: stateBody.getAttribute('stroke-dasharray'),
+      geometryReady: fixture.geometry.isReady(),
+    };
+  }));
+
+  expect(result).toHaveLength(6);
+  result.forEach((shape) => {
+    expect(shape.progress).toBe(35);
+    expect(shape.measurementCount).toBe(1);
+    expect(shape.masterPreserved).toBe(true);
+    expect(shape.backgroundPreserved).toBe(true);
+    expect(shape.featuresPreserved).toBe(true);
+    expect(shape.stateBodyPreserved).toBe(true);
+    expect(shape.dashArray).toBe('35 100');
+    expect(shape.geometryReady).toBe(true);
+  });
+});

--- a/tests/path-animator.test.js
+++ b/tests/path-animator.test.js
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import PathStateAnimator from '../src/path-animator.js';
+import { buildAdaptivePathGradient, setFullPathGradientRevealRange } from '../src/path-gradient-renderer.js';
+
+/** Creates a deterministic requestAnimationFrame queue for animator tests. */
+function createFrameScheduler() {
+  let nextFrame = 1;
+  const callbacks = new Map();
+
+  return {
+    requestFrame: (callback) => {
+      const frame = nextFrame;
+      nextFrame += 1;
+      callbacks.set(frame, callback);
+      return frame;
+    },
+    cancelFrame: (frame) => callbacks.delete(frame),
+    runNextFrame: (timestamp) => {
+      const [frame, callback] = callbacks.entries().next().value;
+      callbacks.delete(frame);
+      callback(timestamp);
+    },
+    pendingFrames: () => callbacks.size,
+  };
+}
+
+test('disabled path animation updates only its bound state layer immediately', () => {
+  const scheduler = createFrameScheduler();
+  const stateLayer = { id: 'state' };
+  const staticLayer = { id: 'static' };
+  const updates = [];
+  const completed = [];
+  const animator = new PathStateAnimator({
+    animation: { enabled: false, duration: 100, easing: 'linear' },
+    initialProgress: 20,
+    requestFrame: scheduler.requestFrame,
+    cancelFrame: scheduler.cancelFrame,
+    updateStateLayer: (element, progress) => updates.push({ element, progress }),
+    onComplete: (progress) => completed.push(progress),
+  });
+
+  animator.bindStateLayer(stateLayer);
+  animator.animateTo(80);
+
+  assert.deepEqual(updates, [
+    { element: stateLayer, progress: 20 },
+    { element: stateLayer, progress: 80 },
+  ]);
+  assert.deepEqual(completed, [80]);
+  assert.equal(updates.some((update) => update.element === staticLayer), false);
+  assert.equal(scheduler.pendingFrames(), 0);
+  assert.equal(animator.animating, false);
+});
+
+test('an interrupted transition continues from its displayed path progress', () => {
+  const scheduler = createFrameScheduler();
+  const updates = [];
+  const completed = [];
+  const animator = new PathStateAnimator({
+    animation: { enabled: true, duration: 100, easing: 'linear' },
+    initialProgress: 20,
+    requestFrame: scheduler.requestFrame,
+    cancelFrame: scheduler.cancelFrame,
+    updateStateLayer: (_element, progress) => updates.push(progress),
+    onComplete: (progress) => completed.push(progress),
+  });
+
+  animator.bindStateLayer({ id: 'state' });
+  animator.animateTo(80);
+  scheduler.runNextFrame(1000);
+  scheduler.runNextFrame(1050);
+  animator.animateTo(100);
+  scheduler.runNextFrame(1100);
+  scheduler.runNextFrame(1150);
+  scheduler.runNextFrame(1200);
+
+  assert.deepEqual(updates, [20, 20, 50, 50, 75, 100]);
+  assert.deepEqual(completed, [100]);
+  assert.equal(animator.currentProgress, 100);
+  assert.equal(animator.animating, false);
+  assert.equal(scheduler.pendingFrames(), 0);
+});
+
+test('stopping a transition preserves the visible state and cancels pending work', () => {
+  const scheduler = createFrameScheduler();
+  const updates = [];
+  const animator = new PathStateAnimator({
+    animation: { enabled: true, duration: 100, easing: 'ease-out' },
+    initialProgress: 10,
+    requestFrame: scheduler.requestFrame,
+    cancelFrame: scheduler.cancelFrame,
+    updateStateLayer: (_element, progress) => updates.push(progress),
+    onComplete: () => {},
+  });
+
+  animator.bindStateLayer({ id: 'state' });
+  animator.animateTo(90);
+  scheduler.runNextFrame(1000);
+  scheduler.runNextFrame(1050);
+  const visibleProgress = animator.currentProgress;
+  animator.stopAnimation();
+
+  assert.equal(visibleProgress, 80);
+  assert.equal(animator.currentProgress, visibleProgress);
+  assert.equal(animator.animating, false);
+  assert.equal(scheduler.pendingFrames(), 0);
+  assert.deepEqual(updates, [10, 10, 80]);
+});
+
+test('full-gradient animation retains adaptive geometry and changes only its reveal range', () => {
+  const scheduler = createFrameScheduler();
+  let lengthReads = 0;
+  let pointReads = 0;
+  const geometry = {
+    getTotalLength: () => {
+      lengthReads += 1;
+      return 100;
+    },
+    pointAtProgress: (progress) => {
+      pointReads += 1;
+      return { x: progress, y: 20 };
+    },
+  };
+  const gradient = buildAdaptivePathGradient(geometry, {
+    mode: 'full',
+    range: { start: 0, end: 20 },
+    colorStops: [
+      { progress: 0, color: '#000000' },
+      { progress: 100, color: '#ffffff' },
+    ],
+    width: 8,
+    startCap: 'round',
+    endCap: 'round',
+    maxSegmentLength: 25,
+    minSegmentLength: 1,
+    maxTangentAngle: 12,
+    maxSegments: 96,
+    overlap: 0.5,
+  });
+  const adaptiveRanges = gradient.ranges;
+  const measurementCounts = { lengthReads, pointReads };
+  const animator = new PathStateAnimator({
+    animation: { enabled: true, duration: 100, easing: 'linear' },
+    initialProgress: 20,
+    requestFrame: scheduler.requestFrame,
+    cancelFrame: scheduler.cancelFrame,
+    updateStateLayer: (_element, progress) => setFullPathGradientRevealRange(gradient, { start: 0, end: progress }),
+    onComplete: () => {},
+  });
+
+  animator.bindStateLayer({ id: 'gradient-state' });
+  animator.animateTo(80);
+  scheduler.runNextFrame(1000);
+  scheduler.runNextFrame(1050);
+  scheduler.runNextFrame(1100);
+
+  assert.equal(gradient.ranges, adaptiveRanges);
+  assert.deepEqual(gradient.revealRange, {
+    id: 'gradient-reveal',
+    start: 0,
+    end: 80,
+    startCap: 'round',
+    endCap: 'round',
+    dash: { array: [80, 100], offset: 0 },
+  });
+  assert.deepEqual({ lengthReads, pointReads }, measurementCounts);
+});

--- a/tests/path-gradient-renderer.test.js
+++ b/tests/path-gradient-renderer.test.js
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { buildAdaptivePathGradient, renderAdaptivePathGradient } from '../src/path-gradient-renderer.js';
+import {
+  buildAdaptivePathGradient,
+  renderAdaptivePathGradient,
+  setFullPathGradientRevealRange,
+} from '../src/path-gradient-renderer.js';
 
 const straightGeometry = {
   getTotalLength: () => 200,
@@ -41,6 +45,23 @@ test('full gradient keeps a static color distribution behind the active reveal r
   assert.equal(first.ranges[0].gradient.startColor, '#000000');
   assert.equal(first.ranges[3].gradient.endColor, '#ff0000ff');
   assert.equal(first.ranges.at(-1).gradient.endColor, '#ffffff');
+});
+
+test('full gradient reveal updates retain adaptive ranges and cap configuration', () => {
+  const gradient = buildAdaptivePathGradient(straightGeometry, baseConfig);
+  const ranges = gradient.ranges;
+  const updated = setFullPathGradientRevealRange(gradient, { start: 15, end: 75 });
+
+  assert.equal(updated, gradient);
+  assert.equal(updated.ranges, ranges);
+  assert.deepEqual(updated.revealRange, {
+    id: 'gradient-reveal',
+    start: 15,
+    end: 75,
+    startCap: 'round',
+    endCap: 'round',
+    dash: { array: [60, 100], offset: -15 },
+  });
 });
 
 test('current gradient redistributes all configured colors over the active range', () => {


### PR DESCRIPTION
Closes #581

- animates normalized path progress inside one explicitly bound state layer
- continues interrupted transitions from the visible progress
- preserves master geometry, backgrounds, features, and state DOM nodes
- updates full-gradient reveal ranges without rebuilding adaptive geometry
- proves one browser measurement across repeated updates on all six path shapes

Validation: npm run build; npx playwright test --reporter=line