### PR TITLE
feat: add side-positioned path geometry

### DIFF
--- a/src/path-generators.js
+++ b/src/path-generators.js
@@ -64,6 +64,263 @@ export function buildLinePathDefinition(config) {
 }
 
 /**
+ * Calculates the final clockwise corner coordinates for a regular polygon.
+ * `top` identifies the exact point along a side that must lie on the vertical
+ * centerline above the polygon. Width and height scale the oriented base
+ * polygon independently; radius keeps the regular polygon proportions.
+ *
+ * @param {object} config - Validated polygon center, size, side count, and top position.
+ * @returns {Array<{x: number, y: number}>} Clockwise polygon corners.
+ */
+export function calculatePolygonPoints(config) {
+  const baseStartAngle = config.sides % 2 === 0
+    ? -Math.PI / 2 - Math.PI / config.sides
+    : -Math.PI / 2;
+  const basePoints = [];
+
+  for (let index = 0; index < config.sides; index += 1) {
+    const angle = baseStartAngle + (index * Math.PI * 2) / config.sides;
+    basePoints.push({ x: Math.cos(angle), y: Math.sin(angle) });
+  }
+
+  // A side position is linear along the actual edge. Rotate that exact point
+  // to twelve o'clock rather than approximating it as an angular fraction.
+  const normalizedTop = config.top === config.sides ? 0 : config.top;
+  const topSide = Math.floor(normalizedTop);
+  const topFraction = normalizedTop - topSide;
+  const topStart = basePoints[topSide];
+  const topEnd = basePoints[(topSide + 1) % config.sides];
+  const topX = topStart.x + (topEnd.x - topStart.x) * topFraction;
+  const topY = topStart.y + (topEnd.y - topStart.y) * topFraction;
+  const rotation = -Math.PI / 2 - Math.atan2(topY, topX);
+  const orientedPoints = basePoints.map((point) => ({
+    x: point.x * Math.cos(rotation) - point.y * Math.sin(rotation),
+    y: point.x * Math.sin(rotation) + point.y * Math.cos(rotation),
+  }));
+
+  if (config.radius !== undefined) {
+    return orientedPoints.map((point) => ({
+      x: config.cx + point.x * config.radius,
+      y: config.cy + point.y * config.radius,
+    }));
+  }
+
+  const xValues = orientedPoints.map((point) => point.x);
+  const yValues = orientedPoints.map((point) => point.y);
+  const scaleX = config.width / (Math.max(...xValues) - Math.min(...xValues));
+  const scaleY = config.height / (Math.max(...yValues) - Math.min(...yValues));
+
+  return orientedPoints.map((point) => ({
+    x: config.cx + point.x * scaleX,
+    y: config.cy + point.y * scaleY,
+  }));
+}
+
+/**
+ * Builds one continuous regular-polygon centerline between numeric side
+ * positions. Integers identify corners and decimals identify positions along
+ * the following side. Direction changes traversal without changing numbering.
+ *
+ * @param {object} config - Validated polygon geometry and selected side range.
+ * @returns {object} Stable polygon path definition.
+ */
+export function buildPolygonPathDefinition(config) {
+  const points = calculatePolygonPoints(config);
+  const pointAtPosition = (position) => {
+    const wrappedPosition = ((position % config.sides) + config.sides) % config.sides;
+    const side = Math.floor(wrappedPosition);
+    const fraction = wrappedPosition - side;
+    const sideStart = points[side];
+    const sideEnd = points[(side + 1) % config.sides];
+
+    return {
+      x: sideStart.x + (sideEnd.x - sideStart.x) * fraction,
+      y: sideStart.y + (sideEnd.y - sideStart.y) * fraction,
+    };
+  };
+  const startPoint = pointAtPosition(config.start);
+  const commands = [`M ${startPoint.x} ${startPoint.y}`];
+
+  if (config.start === config.end) return createPathDefinition(commands[0], false);
+
+  if (config.direction === 'clockwise') {
+    const traversalEnd = config.end < config.start ? config.end + config.sides : config.end;
+
+    for (let position = Math.floor(config.start) + 1; position < traversalEnd; position += 1) {
+      const point = pointAtPosition(position);
+      commands.push(`L ${point.x} ${point.y}`);
+    }
+
+    const endPoint = pointAtPosition(traversalEnd);
+    commands.push(`L ${endPoint.x} ${endPoint.y}`);
+  } else {
+    const traversalEnd = config.end > config.start ? config.end - config.sides : config.end;
+
+    for (let position = Math.ceil(config.start) - 1; position > traversalEnd; position -= 1) {
+      const point = pointAtPosition(position);
+      commands.push(`L ${point.x} ${point.y}`);
+    }
+
+    const endPoint = pointAtPosition(traversalEnd);
+    commands.push(`L ${endPoint.x} ${endPoint.y}`);
+  }
+
+  const closed = Math.abs(config.end - config.start) === config.sides;
+  if (closed) commands.push('Z');
+
+  return createPathDefinition(commands.join(' '), closed);
+}
+
+/**
+ * Builds one continuous rounded-rectangle centerline between numeric side
+ * positions. Every integer lies halfway around a corner. Each side therefore
+ * includes the second half of its starting corner and the first half of its
+ * ending corner, and decimal positions remain proportional when size changes.
+ *
+ * @param {object} config - Validated rectangle center, dimensions, radii, and side range.
+ * @returns {object} Stable rounded rectangle path definition.
+ */
+export function buildSidePositionedRectanglePathDefinition(config) {
+  const left = config.cx - config.width / 2;
+  const top = config.cy - config.height / 2;
+  const right = config.cx + config.width / 2;
+  const bottom = config.cy + config.height / 2;
+  const radii = [config.radiusTopLeft, config.radiusTopRight, config.radiusBottomRight, config.radiusBottomLeft];
+  const arc = (cx, cy, radius, startAngle, endAngle) => ({
+    type: 'arc', cx, cy, radius, startAngle, endAngle,
+    length: radius * Math.abs(endAngle - startAngle) * Math.PI / 180,
+  });
+  const line = (x1, y1, x2, y2) => ({
+    type: 'line', x1, y1, x2, y2,
+    length: Math.hypot(x2 - x1, y2 - y1),
+  });
+  const sides = [
+    [
+      arc(left + radii[0], top + radii[0], radii[0], 225, 270),
+      line(left + radii[0], top, right - radii[1], top),
+      arc(right - radii[1], top + radii[1], radii[1], 270, 315),
+    ],
+    [
+      arc(right - radii[1], top + radii[1], radii[1], 315, 360),
+      line(right, top + radii[1], right, bottom - radii[2]),
+      arc(right - radii[2], bottom - radii[2], radii[2], 0, 45),
+    ],
+    [
+      arc(right - radii[2], bottom - radii[2], radii[2], 45, 90),
+      line(right - radii[2], bottom, left + radii[3], bottom),
+      arc(left + radii[3], bottom - radii[3], radii[3], 90, 135),
+    ],
+    [
+      arc(left + radii[3], bottom - radii[3], radii[3], 135, 180),
+      line(left, bottom - radii[3], left, top + radii[0]),
+      arc(left + radii[0], top + radii[0], radii[0], 180, 225),
+    ],
+  ];
+  const pointOnSegment = (segment, progress) => {
+    if (segment.type === 'line') {
+      return {
+        x: segment.x1 + (segment.x2 - segment.x1) * progress,
+        y: segment.y1 + (segment.y2 - segment.y1) * progress,
+      };
+    }
+
+    const angle = (segment.startAngle + (segment.endAngle - segment.startAngle) * progress) * Math.PI / 180;
+    return {
+      x: segment.cx + segment.radius * Math.cos(angle),
+      y: segment.cy + segment.radius * Math.sin(angle),
+    };
+  };
+  const sidePoint = (side, fraction) => {
+    const sideLength = sides[side].reduce((total, segment) => total + segment.length, 0);
+    const distance = sideLength * fraction;
+    let consumed = 0;
+
+    for (const segment of sides[side]) {
+      if (distance <= consumed + segment.length || segment === sides[side][sides[side].length - 1]) {
+        const progress = segment.length === 0 ? 1 : (distance - consumed) / segment.length;
+        return pointOnSegment(segment, progress);
+      }
+      consumed += segment.length;
+    }
+  };
+  const pointAtPosition = (position) => {
+    const wrappedPosition = ((position % 4) + 4) % 4;
+    const side = Math.floor(wrappedPosition);
+    return sidePoint(side, wrappedPosition - side);
+  };
+
+  // Rotate the generated centerline itself. Every later path layer and label
+  // consumes these final coordinates and needs no compensating SVG transform.
+  const topPoint = pointAtPosition(config.top);
+  const rotation = -Math.PI / 2 - Math.atan2(topPoint.y - config.cy, topPoint.x - config.cx);
+  const rotatePoint = (point) => ({
+    x: config.cx + (point.x - config.cx) * Math.cos(rotation) - (point.y - config.cy) * Math.sin(rotation),
+    y: config.cy + (point.x - config.cx) * Math.sin(rotation) + (point.y - config.cy) * Math.cos(rotation),
+  });
+  const appendSideRange = (commands, side, fromFraction, toFraction, direction) => {
+    const segments = sides[side];
+    const sideLength = segments.reduce((total, segment) => total + segment.length, 0);
+    const rangeStart = sideLength * Math.min(fromFraction, toFraction);
+    const rangeEnd = sideLength * Math.max(fromFraction, toFraction);
+    const orderedSegments = direction === 'clockwise' ? segments : [...segments].reverse();
+    let consumed = direction === 'clockwise' ? 0 : sideLength;
+
+    orderedSegments.forEach((segment) => {
+      const segmentStart = direction === 'clockwise' ? consumed : consumed - segment.length;
+      const segmentEnd = direction === 'clockwise' ? consumed + segment.length : consumed;
+      consumed += direction === 'clockwise' ? segment.length : -segment.length;
+      const overlapStart = Math.max(rangeStart, segmentStart);
+      const overlapEnd = Math.min(rangeEnd, segmentEnd);
+
+      if (overlapEnd <= overlapStart || segment.length === 0) return;
+
+      const forwardStart = (overlapStart - segmentStart) / segment.length;
+      const forwardEnd = (overlapEnd - segmentStart) / segment.length;
+      const targetProgress = direction === 'clockwise' ? forwardEnd : forwardStart;
+      const target = rotatePoint(pointOnSegment(segment, targetProgress));
+
+      if (segment.type === 'line') {
+        commands.push(`L ${target.x} ${target.y}`);
+      } else {
+        commands.push(`A ${segment.radius} ${segment.radius} 0 0 ${direction === 'clockwise' ? 1 : 0} ${target.x} ${target.y}`);
+      }
+    });
+  };
+  const startPoint = rotatePoint(pointAtPosition(config.start));
+  const commands = [`M ${startPoint.x} ${startPoint.y}`];
+
+  if (config.start === config.end) return createPathDefinition(commands[0], false);
+
+  if (config.direction === 'clockwise') {
+    const traversalEnd = config.end < config.start ? config.end + 4 : config.end;
+    let position = config.start;
+
+    while (position < traversalEnd) {
+      const sideBase = Math.floor(position);
+      const nextPosition = Math.min(traversalEnd, sideBase + 1);
+      appendSideRange(commands, ((sideBase % 4) + 4) % 4, position - sideBase, nextPosition - sideBase, 'clockwise');
+      position = nextPosition;
+    }
+  } else {
+    const traversalEnd = config.end > config.start ? config.end - 4 : config.end;
+    let position = config.start;
+
+    while (position > traversalEnd) {
+      const startsAtCorner = Number.isInteger(position);
+      const sideBase = startsAtCorner ? position - 1 : Math.floor(position);
+      const nextPosition = Math.max(traversalEnd, sideBase);
+      appendSideRange(commands, ((sideBase % 4) + 4) % 4, position - sideBase, nextPosition - sideBase, 'counterclockwise');
+      position = nextPosition;
+    }
+  }
+
+  const closed = Math.abs(config.end - config.start) === 4;
+  if (closed) commands.push('Z');
+
+  return createPathDefinition(commands.join(' '), closed);
+}
+
+/**
  * Builds a closed rectangular centerline with independent corner radii. The
  * start side changes only the path origin; direction controls traversal order.
  *
@@ -216,6 +473,8 @@ export function buildPathDefinition(config) {
       return buildLinePathDefinition(config);
     case 'rectangle':
       return buildRectanglePathDefinition(config);
+    case 'polygon':
+      return buildPolygonPathDefinition(config);
     case 'wave':
       return buildWavePathDefinition(config);
     case 'spiral':

--- a/tests/path-generators.test.js
+++ b/tests/path-generators.test.js
@@ -6,9 +6,12 @@ import {
   buildInfinityPathDefinition,
   buildLinePathDefinition,
   buildPathDefinition,
+  buildPolygonPathDefinition,
   buildRectanglePathDefinition,
+  buildSidePositionedRectanglePathDefinition,
   buildSpiralPathDefinition,
   buildWavePathDefinition,
+  calculatePolygonPoints,
 } from '../src/path-generators.js';
 
 test('arc generator builds partial clockwise and counter-clockwise centerlines', () => {
@@ -109,6 +112,88 @@ test('rectangle generator changes origin and traversal without changing its boun
 
   assert.match(definition.d, /^M 90 50 L 90 20/);
   assert.match(definition.d, /L 90 50 Z$/);
+});
+
+test('polygon points keep the natural odd and even top orientation', () => {
+  const triangle = calculatePolygonPoints({ cx: 50, cy: 50, sides: 3, radius: 40, top: 0 });
+  const hexagon = calculatePolygonPoints({ cx: 50, cy: 50, sides: 6, radius: 40, top: 0.5 });
+
+  assert.ok(Math.abs(triangle[0].x - 50) < 1e-10);
+  assert.equal(triangle[0].y, 10);
+  assert.ok(Math.abs(hexagon[0].y - hexagon[1].y) < 1e-10);
+  assert.ok(Math.abs((hexagon[0].x + hexagon[1].x) / 2 - 50) < 1e-10);
+});
+
+test('polygon width and height produce exact outer dimensions', () => {
+  const points = calculatePolygonPoints({ cx: 50, cy: 50, sides: 5, width: 80, height: 60, top: 0 });
+  const xValues = points.map((point) => point.x);
+  const yValues = points.map((point) => point.y);
+
+  assert.ok(Math.abs(Math.max(...xValues) - Math.min(...xValues) - 80) < 1e-10);
+  assert.ok(Math.abs(Math.max(...yValues) - Math.min(...yValues) - 60) < 1e-10);
+});
+
+test('polygon generator selects decimal side positions in both directions', () => {
+  const clockwise = buildPolygonPathDefinition({
+    type: 'polygon', cx: 50, cy: 50, sides: 4, width: 80, height: 60,
+    top: 0.5, start: 3.5, end: 1.5, direction: 'clockwise',
+  });
+  const counterClockwise = buildPolygonPathDefinition({
+    type: 'polygon', cx: 50, cy: 50, sides: 4, width: 80, height: 60,
+    top: 0.5, start: 1.5, end: 3.5, direction: 'counterclockwise',
+  });
+
+  assert.equal(clockwise.closed, false);
+  assert.equal(counterClockwise.closed, false);
+  assert.match(clockwise.d, /^M 10 50 L 10 /);
+  assert.match(clockwise.d, / L 90 50$/);
+  assert.match(counterClockwise.d, /^M 90 50 L 90 /);
+  assert.match(counterClockwise.d, / L 10 50$/);
+  assert.equal(buildPathDefinition({
+    type: 'polygon', cx: 50, cy: 50, sides: 4, width: 80, height: 60,
+    top: 0.5, start: 3.5, end: 1.5, direction: 'clockwise',
+  }).signature, clockwise.signature);
+});
+
+test('polygon generator distinguishes zero length from an exact complete path', () => {
+  const config = {
+    type: 'polygon', cx: 50, cy: 50, sides: 6, radius: 40,
+    top: 0.5, direction: 'clockwise',
+  };
+  const empty = buildPolygonPathDefinition({ ...config, start: 0, end: 0 });
+  const complete = buildPolygonPathDefinition({ ...config, start: 0, end: 6 });
+
+  assert.equal(empty.closed, false);
+  assert.doesNotMatch(empty.d, / L /);
+  assert.equal(complete.closed, true);
+  assert.match(complete.d, / Z$/);
+  assert.equal((complete.d.match(/ L /g) ?? []).length, 6);
+});
+
+test('side-positioned rectangle builds the same roof at every size', () => {
+  const definition = buildSidePositionedRectanglePathDefinition({
+    cx: 50, cy: 50, width: 80, height: 60,
+    radiusTopLeft: 0, radiusTopRight: 0, radiusBottomRight: 0, radiusBottomLeft: 0,
+    top: 0.5, start: 3.5, end: 1.5, direction: 'clockwise',
+  });
+
+  assert.equal(definition.closed, false);
+  assert.equal(definition.d, 'M 10 50 L 10 20 L 90 20 L 90 50');
+});
+
+test('side-positioned rectangle assigns integer positions to rounded-corner midpoints', () => {
+  const definition = buildSidePositionedRectanglePathDefinition({
+    cx: 50, cy: 50, width: 80, height: 60,
+    radiusTopLeft: 10, radiusTopRight: 10, radiusBottomRight: 10, radiusBottomLeft: 10,
+    top: 0.5, start: 0, end: 4, direction: 'clockwise',
+  });
+  const [, startX, startY] = definition.d.match(/^M ([^ ]+) ([^ ]+)/);
+
+  assert.ok(Math.abs(Number(startX) - (20 + 10 * Math.cos(225 * Math.PI / 180))) < 1e-10);
+  assert.ok(Math.abs(Number(startY) - (30 + 10 * Math.sin(225 * Math.PI / 180))) < 1e-10);
+  assert.equal(definition.closed, true);
+  assert.equal((definition.d.match(/ A /g) ?? []).length, 8);
+  assert.match(definition.d, / Z$/);
 });
 
 test('wave generator preserves endpoints and emits two cubic halves per wave', () => {

--- a/tests/path-side-positions.browser.spec.js
+++ b/tests/path-side-positions.browser.spec.js
@@ -1,0 +1,105 @@
+import { readFile } from 'node:fs/promises';
+
+import { expect, test } from '@playwright/test';
+
+test('browser geometry measures polygon and rounded rectangle side ranges as one path', async ({ page }) => {
+  const generatorSource = await readFile(new URL('../src/path-generators.js', import.meta.url), 'utf8');
+  const measurements = await page.evaluate(async (source) => {
+    const moduleUrl = URL.createObjectURL(new Blob([source], { type: 'text/javascript' }));
+    const {
+      buildPolygonPathDefinition,
+      buildSidePositionedRectanglePathDefinition,
+      calculatePolygonPoints,
+    } = await import(moduleUrl);
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    document.body.append(svg);
+    const polygonConfig = {
+      cx: 100, cy: 100, sides: 6, width: 140, height: 100,
+      top: 0.1, start: 5.5, end: 2.5, direction: 'clockwise',
+    };
+    const rectangleConfig = {
+      cx: 100, cy: 100, width: 140, height: 90,
+      radiusTopLeft: 12, radiusTopRight: 12, radiusBottomRight: 12, radiusBottomLeft: 12,
+      top: 0.5, start: 3.5, end: 1.5, direction: 'clockwise',
+    };
+    const definitions = [
+      buildPolygonPathDefinition(polygonConfig),
+      buildSidePositionedRectanglePathDefinition(rectangleConfig),
+    ];
+    const measured = definitions.map((definition) => {
+      const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+      path.setAttribute('d', definition.d);
+      svg.append(path);
+      const length = path.getTotalLength();
+      const start = path.getPointAtLength(0);
+      const middle = path.getPointAtLength(length / 2);
+      const end = path.getPointAtLength(length);
+
+      return {
+        commandCount: path.getPathData ? path.getPathData().length : definition.d.match(/[MLAZ]/g).length,
+        length,
+        start: { x: start.x, y: start.y },
+        middle: { x: middle.x, y: middle.y },
+        end: { x: end.x, y: end.y },
+      };
+    });
+    const polygonPoints = calculatePolygonPoints(polygonConfig);
+    const topStart = polygonPoints[0];
+    const topEnd = polygonPoints[1];
+    const configuredTop = {
+      x: topStart.x + (topEnd.x - topStart.x) * 0.1,
+      y: topStart.y + (topEnd.y - topStart.y) * 0.1,
+    };
+
+    URL.revokeObjectURL(moduleUrl);
+    return { measured, configuredTop };
+  }, generatorSource);
+
+  const [polygon, rectangle] = measurements.measured;
+
+  expect(polygon.commandCount).toBeGreaterThan(3);
+  expect(polygon.length).toBeGreaterThan(150);
+  expect(polygon.start.x).not.toBeCloseTo(polygon.end.x, 4);
+  expect(polygon.start.y).not.toBeCloseTo(polygon.end.y, 4);
+  expect(measurements.configuredTop.x).toBeCloseTo(100, 4);
+  expect(measurements.configuredTop.y).toBeLessThan(100);
+
+  expect(rectangle.commandCount).toBeGreaterThan(4);
+  expect(rectangle.length).toBeGreaterThan(180);
+  expect(rectangle.start.x).toBeCloseTo(30, 4);
+  expect(rectangle.start.y).toBeCloseTo(100, 4);
+  expect(rectangle.middle.x).toBeCloseTo(100, 4);
+  expect(rectangle.middle.y).toBeCloseTo(55, 4);
+  expect(rectangle.end.x).toBeCloseTo(170, 4);
+  expect(rectangle.end.y).toBeCloseTo(100, 4);
+});
+
+test('browser geometry closes only an explicitly complete side range', async ({ page }) => {
+  const generatorSource = await readFile(new URL('../src/path-generators.js', import.meta.url), 'utf8');
+  const result = await page.evaluate(async (source) => {
+    const moduleUrl = URL.createObjectURL(new Blob([source], { type: 'text/javascript' }));
+    const { buildPolygonPathDefinition } = await import(moduleUrl);
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    document.body.append(svg);
+    const base = {
+      cx: 50, cy: 50, sides: 5, radius: 40, top: 0,
+      direction: 'clockwise',
+    };
+    const emptyDefinition = buildPolygonPathDefinition({ ...base, start: 0, end: 0 });
+    const completeDefinition = buildPolygonPathDefinition({ ...base, start: 0, end: 5 });
+    const lengths = [emptyDefinition, completeDefinition].map((definition) => {
+      const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+      path.setAttribute('d', definition.d);
+      svg.append(path);
+      return path.getTotalLength();
+    });
+
+    URL.revokeObjectURL(moduleUrl);
+    return { emptyDefinition, completeDefinition, lengths };
+  }, generatorSource);
+
+  expect(result.emptyDefinition.closed).toBe(false);
+  expect(result.lengths[0]).toBe(0);
+  expect(result.completeDefinition.closed).toBe(true);
+  expect(result.lengths[1]).toBeGreaterThan(200);
+});


### PR DESCRIPTION
## Summary

- add clockwise regular-polygon point generation with exact numeric `top` placement
- add partial and complete polygon centerlines using numeric side positions
- add rounded rectangle centerlines whose integer positions lie halfway around corners
- cover radius and width/height sizing, both directions, zero-length paths, full closure, and browser SVG measurement

## Validation

- `npm run build`
- `npx playwright test tests/path-side-positions.browser.spec.js`

Closes #611
