### PR TITLE
docs: explain polygon shapes and paths

### DIFF
--- a/docs/docs/card-basics/positioning-and-sizing.md
+++ b/docs/docs/card-basics/positioning-and-sizing.md
@@ -68,6 +68,7 @@ Use `layout.aspectratio` to make the card square, wide, or tall:
 | Arc and horseshoe | `radius`, `arc_degrees` |
 | Line | `length`, `thickness` |
 | Rectangle | `width`, `height`, `radius` |
+| Polygon | `radius`, or `width` and `height` |
 | Sparkline and control | `width`, `height` |
 
 ## :material-horseshoe: Move related tools together

--- a/docs/docs/reference/configuration-reference.md
+++ b/docs/docs/reference/configuration-reference.md
@@ -35,6 +35,7 @@ Use this page to find the detailed configuration for a card area. The product gu
 | `lines` | [Line](../tools/shapes/line-tool.md) |
 | `circles` | [Circle](../tools/shapes/circle-tool.md) |
 | `arcs` | [Arc](../tools/shapes/arc-tool.md) |
+| `polygons` | [Polygon](../tools/shapes/polygon-tool.md) |
 | `rectangles` | [Rectangle](../tools/shapes/rectangle-tool.md) |
 | `horseshoes` | [Horseshoe](../tools/horseshoe/horseshoe-overview.md) |
 | `sparklines` | [Sparkline](../tools/sparkline/sparkline-overview.md) |

--- a/docs/docs/tools/horseshoe/horseshoe-overview.md
+++ b/docs/docs/tools/horseshoe/horseshoe-overview.md
@@ -87,6 +87,8 @@ Scale and state behavior are covered in [Horseshoe Scale and State](horseshoe-sc
 
 A horseshoe can also inherit its position from a group. See [Positioning and Groups](../../card-basics/positioning-and-sizing.md) and [Groups Section](../../card-basics/groups.md).
 
+The gauge can follow a rectangle, polygon, line, wave, spiral, or infinity symbol instead of an arc. See [Horseshoe path shapes](horseshoe-path-shapes.md) for examples and configuration.
+
 ## :material-horseshoe: Show options
 
 Visibility and presentation settings are grouped under `show`.
@@ -143,6 +145,7 @@ Common SVG properties include `fill`, `stroke`, `stroke-width`, `opacity`, `fill
 
 * [Horseshoe Scale and State](horseshoe-scale-and-state.md)
 * [Horseshoe Tick Marks and Labels](horseshoe-tick-marks-and-labels.md)
+* [Horseshoe Path Shapes](horseshoe-path-shapes.md)
 * [Color Stops](../../appearance/color-stops.md)
 * [Animations](../../interaction/animations.md)
 * [Reusable YAML Card Examples](../../reuse/reuse-introduction.md)

--- a/docs/docs/tools/horseshoe/horseshoe-path-shapes.md
+++ b/docs/docs/tools/horseshoe/horseshoe-path-shapes.md
@@ -1,0 +1,203 @@
+---
+template: main.html
+title: Horseshoe Path Shapes
+description: Draw a Flexible Horseshoe Card gauge along an arc, rectangle, polygon, line, wave, spiral, or infinity path.
+tags:
+  - Horseshoe
+  - Paths
+  - Polygon
+  - Rectangle
+---
+
+# Horseshoe path shapes
+
+A horseshoe can follow more than a circular arc. Use another path when a gauge should follow the edge of a panel, form a roof over a value, or become a triangle, hexagon, wave, spiral, or infinity symbol.
+
+The scale, state, colors, tick marks, labels, and animation continue to work along the selected shape.
+
+<!-- Add horseshoe path shape showcase image -->
+
+## :material-horseshoe: Choose a path
+
+Add `path` to a horseshoe and select its `type`. This example draws a complete hexagonal gauge:
+
+```yaml linenums="1"
+layout:
+  horseshoes:
+    - entity_index: 0
+      xpos: 50
+      ypos: 50
+      path:
+        type: polygon
+        sides: 6
+        radius: 38
+
+      horseshoe_scale:
+        min: 0
+        max: 100
+
+      horseshoe_state:
+        width: 8
+```
+
+| Path type | Use |
+| --- | --- |
+| `arc` | A circular or elliptical gauge. |
+| `line` | A straight gauge at any angle. |
+| `rectangle` | A complete border or a selected route around a panel. |
+| `polygon` | A triangle, hexagon, or another regular polygon. |
+| `wave` | A repeating wave. |
+| `spiral` | A gauge that winds outward. |
+| `infinity` | A continuous figure-eight gauge. |
+
+Without `path`, the horseshoe uses its normal circular arc.
+
+## :material-horseshoe: Follow part of a rectangle or polygon
+
+Rectangle and polygon positions use clockwise corner numbers. A decimal selects a point along the following side:
+
+```text
+Rectangle             Triangle              Hexagon
+
+0 ------- 1               0                   0 --- 1
+|         |              / \                 /       \
+|         |             /   \               5         2
+3 ------- 2            2 --- 1               \       /
+                                               4 --- 3
+```
+
+For example, `0.5` is halfway from corner `0` to corner `1`. On a rectangle, `4` is the end of the final side and returns to corner `0`.
+
+Use `start` and `end` to choose the visible route. This rectangle follows the left half of the top-left corner, the complete top side, and the right half of the top-right corner. It forms a roof that keeps the same proportions at every size:
+
+```yaml linenums="1"
+path:
+  type: rectangle
+  width: 80
+  height: 50
+  radius: 3
+  start: 3.5
+  end: 1.5
+  direction: clockwise
+```
+
+Use the complete range when the gauge should follow the entire shape:
+
+| Shape | Complete path |
+| --- | --- |
+| Rectangle | `start: 0`, `end: 4` |
+| Triangle | `start: 0`, `end: 3` |
+| Hexagon | `start: 0`, `end: 6` |
+
+These are also the defaults, so a complete shape does not need `start` or `end`.
+
+## :material-horseshoe: Choose the direction
+
+`direction: clockwise` follows the increasing corner numbers. `direction: counterclockwise` travels around the same shape in the other direction.
+
+```yaml linenums="1"
+path:
+  type: polygon
+  sides: 6
+  radius: 38
+  start: 0
+  end: 4
+  direction: counterclockwise
+```
+
+The direction determines how the state grows from the configured start. It does not change the corner numbers.
+
+## :material-horseshoe: Choose what faces upward
+
+Use `top` to place a corner or a point along a side at the top of the shape:
+
+| Value | Result |
+| --- | --- |
+| `top: 0` | Corner `0` faces upward. |
+| `top: 0.5` | The middle of side `0` to `1` faces upward. |
+| `top: 0.1` | The point ten percent along side `0` to `1` faces upward. |
+
+Odd-sided polygons use `top: 0` by default, which places a corner at the top. Even-sided polygons and rectangles use `top: 0.5`, which makes the upper side horizontal.
+
+Because `top` belongs to the shape itself, tick marks and labels stay correctly positioned and readable.
+
+## :material-horseshoe: Size a polygon
+
+Use a radius for a regular polygon:
+
+```yaml linenums="1"
+path:
+  type: polygon
+  sides: 5
+  radius: 38
+```
+
+Use both `width` and `height` when the polygon must fit exact dimensions:
+
+```yaml linenums="1"
+path:
+  type: polygon
+  sides: 6
+  width: 80
+  height: 55
+```
+
+Do not combine `radius` with `width` and `height`.
+
+## :material-horseshoe: Keep nested paths aligned
+
+Use the same `start`, `end`, `top`, and `direction` for nested rectangles or polygons. Change only their size. Each path then starts and ends at the same relative place on its own shape:
+
+```yaml linenums="1"
+layout:
+  horseshoes:
+    - id: outer-roof
+      entity_index: 0
+      xpos: 50
+      ypos: 50
+      path:
+        type: rectangle
+        width: 82
+        height: 54
+        radius: 3
+        start: 3.5
+        end: 1.5
+
+    - id: inner-roof
+      same_as: outer-roof
+      path:
+        type: rectangle
+        width: 68
+        height: 42
+        radius: 3
+        start: 3.5
+        end: 1.5
+```
+
+See [Reuse™](../../reuse/reuse-introduction.md) when several gauges share more configuration.
+
+## :material-horseshoe: Rectangle and polygon options
+
+| Field | Applies to | Required | Default | Description |
+| --- | --- | :---: | --- | --- |
+| `path.type` | Both | Yes | | `rectangle` or `polygon`. |
+| `path.width` | Both | Rectangle: No; polygon: one size | `80` for rectangle | Exact shape width. |
+| `path.height` | Both | Rectangle: No; polygon: one size | `80` for rectangle | Exact shape height. |
+| `path.radius` | Both | Polygon: one size | `0` for rectangle | Rectangle corner radius or polygon center-to-corner radius. |
+| `path.sides` | Polygon | Yes | | Number of sides; use an integer of `3` or greater. |
+| `path.start` | Both | No | `0` | Position where the path begins. |
+| `path.end` | Both | No | `4` or `sides` | Position where the path ends. |
+| `path.direction` | Both | No | `clockwise` | `clockwise` or `counterclockwise`. |
+| `path.top` | Both | No | `0.5` for even sides; `0` for odd sides | Position that faces upward. |
+
+The [Horseshoe overview](horseshoe-overview.md), [Scale and state](horseshoe-scale-and-state.md), and [Tick marks and labels](horseshoe-tick-marks-and-labels.md) describe the settings shared by all path shapes.
+
+See the [path-shape showcase](https://github.com/AmoebeLabs/flex-horseshoe-card/blob/master/examples/view-fhs-horseshoe-path-shapes.yaml) for complete arc, line, rectangle, polygon, wave, spiral, and infinity examples.
+
+## :material-horseshoe: Related
+
+* [Horseshoe overview](horseshoe-overview.md)
+* [Polygon](../shapes/polygon-tool.md)
+* [Scale and state](horseshoe-scale-and-state.md)
+* [Tick marks and labels](horseshoe-tick-marks-and-labels.md)
+* [Color stops](../../appearance/color-stops.md)

--- a/docs/docs/tools/shapes/polygon-tool.md
+++ b/docs/docs/tools/shapes/polygon-tool.md
@@ -1,0 +1,163 @@
+---
+template: main.html
+title: Polygon
+description: Add triangles, hexagons, and other regular polygon shapes to a Flexible Horseshoe Card.
+tags:
+  - Polygon
+  - Shapes
+  - Card tools
+---
+
+# Polygon
+
+A polygon adds a triangle, hexagon, or another regular shape anywhere on the card. Use it as a background, border, status surface, or as the matching background for a polygon-shaped horseshoe.
+
+<!-- Add polygon tool examples image -->
+
+## :material-horseshoe: Basic configuration
+
+Add polygons under `layout.polygons`. Choose the number of sides and give the shape either a radius or an exact width and height:
+
+```yaml linenums="1"
+layout:
+  polygons:
+    - id: status-background
+      xpos: 50
+      ypos: 50
+      sides: 6
+      radius: 35
+      styles:
+        fill: var(--primary-color)
+        fill-opacity: 0.2
+        stroke: var(--primary-color)
+        stroke-width: 1
+```
+
+An odd-sided polygon points upward by default. An even-sided polygon has a horizontal side at the top.
+
+## :material-horseshoe: Choose the size
+
+Use `radius` when the polygon should keep its regular proportions:
+
+```yaml linenums="1"
+layout:
+  polygons:
+    - xpos: 50
+      ypos: 50
+      sides: 5
+      radius: 35
+```
+
+Use `width` and `height` when the polygon must fit an exact area. Both fields are required together:
+
+```yaml linenums="1"
+layout:
+  polygons:
+    - xpos: 50
+      ypos: 50
+      sides: 6
+      width: 80
+      height: 55
+```
+
+## :material-horseshoe: Choose what faces upward
+
+Corner numbers increase clockwise. A decimal identifies a point along the side leading to the next corner:
+
+```text
+Triangle              Hexagon
+
+    0                  0 --- 1
+   / \                /       \
+  2---1              5         2
+                      \       /
+                       4 --- 3
+```
+
+`top` places one of these positions at the top of the shape:
+
+| Value | Result |
+| --- | --- |
+| `top: 0` | Corner `0` faces upward. |
+| `top: 0.5` | The middle of the side from `0` to `1` faces upward. |
+| `top: 0.1` | The point ten percent along the side from `0` to `1` faces upward. |
+
+This example turns a hexagon until corner `0` is at the top:
+
+```yaml linenums="1"
+layout:
+  polygons:
+    - xpos: 50
+      ypos: 50
+      sides: 6
+      radius: 35
+      top: 0
+```
+
+## :material-horseshoe: Match a polygon horseshoe
+
+A polygon and a polygon-shaped horseshoe match exactly when their position, size, number of sides, and `top` value are equal. This lets you place a filled surface behind a gauge:
+
+```yaml linenums="1"
+layout:
+  polygons:
+    - xpos: 50
+      ypos: 50
+      sides: 6
+      width: 80
+      height: 55
+      top: 0.5
+      styles:
+        fill: var(--primary-color)
+        fill-opacity: 0.12
+
+  horseshoes:
+    - entity_index: 0
+      xpos: 50
+      ypos: 50
+      path:
+        type: polygon
+        sides: 6
+        width: 80
+        height: 55
+        top: 0.5
+      horseshoe_scale:
+        min: 0
+        max: 100
+```
+
+See [Horseshoe path shapes](../horseshoe/horseshoe-path-shapes.md) for partial polygon gauges and direction settings.
+
+## :material-horseshoe: Configuration options
+
+| Field | Required | Default | Description |
+| --- | :---: | --- | --- |
+| `xpos` | Yes | | Horizontal center position. |
+| `ypos` | Yes | | Vertical center position. |
+| `sides` | Yes | | Number of sides; use an integer of `3` or greater. |
+| `radius` | One size | | Distance from the center to each corner. |
+| `width` | One size | | Exact width; requires `height`. |
+| `height` | One size | | Exact height; requires `width`. |
+| `top` | No | `0` for odd sides; `0.5` for even sides | Side position that faces upward. |
+| `fill_mask` | No | `auto` | Fill width removed along the inside of the outline. |
+| `entity_index` | No | Not set | Entity used for value-dependent colors, actions, and animations. |
+| `styles` | No | Default polygon style | Fill, outline, opacity, and other SVG styles. |
+| `color_stops` | No | Not set | Colors the polygon from its entity value. |
+
+Use either `radius`, or use `width` and `height`. Do not combine both sizing methods.
+
+## :material-horseshoe: Styling and interaction
+
+Polygons support the same fill and outline styles as rectangles. When both are translucent, `fill_mask: auto` prevents their colors from becoming darker where they meet.
+
+Connect a polygon through `entity_index` when its color or behavior should follow an entity. Continue with [Color stops](../../appearance/color-stops.md), [Color filters](../../appearance/color-filters.md), [Actions](../../interaction/actions.md), and [Animations](../../interaction/animations.md).
+
+The [complete polygon and horseshoe example](https://github.com/AmoebeLabs/flex-horseshoe-card/blob/master/examples/fhs-card-polygon-horseshoe-v1.yaml) combines a filled polygon, a matching gauge, a state, and a slider.
+
+## :material-horseshoe: Related
+
+* [Horseshoe path shapes](../horseshoe/horseshoe-path-shapes.md)
+* [Rectangle](rectangle-tool.md)
+* [Positioning and sizing](../../card-basics/positioning-and-sizing.md)
+* [Styling](../../appearance/styling.md)
+* [Reuse™](../../reuse/reuse-introduction.md)

--- a/docs/docs/tools/shapes/shapes-overview.md
+++ b/docs/docs/tools/shapes/shapes-overview.md
@@ -1,9 +1,10 @@
 ---
 template: main.html
 title: Visual Shapes
-description: Configure rectangles, circles, horizontal lines, and vertical lines as positioned and styled visual building blocks in card layouts.
+description: Configure rectangles, polygons, circles, and lines as positioned and styled visual building blocks in card layouts.
 tags:
 - Rectangles
+- Polygons
 - Circles
 - Horizontal Lines
 - Vertical Lines
@@ -11,20 +12,21 @@ tags:
 
 [line-tool support]: https://github.com/amoebelabs/swiss-army-knife-card/releases/
 
-# Visual shapes: rectangles, lines, and circles
+# Visual shapes
 
 Visual shapes are simple SVG building blocks that help organize and enhance a card layout. Use them as separators, backgrounds, highlights, indicators, or decorative elements.
 
-The card supports four shape sections:
+Choose the shape that matches the visual element you want to add:
 
 | Shape           | Section      | Description                                                                        |
 | :-------------- | :----------- | :--------------------------------------------------------------------------------- |
 | Rectangle       | `rectangles` | A fixed rectangle or one that automatically fits another layout item               |
+| Polygon         | `polygons`   | A triangle, hexagon, or another regular shape                                      |
 | Circle          | `circles`    | A circle positioned by its center point, using either `radius` or `radius_percent` |
 | Horizontal line | `hlines`     | A horizontal line positioned by its center point and length                        |
 | Vertical line   | `vlines`     | A vertical line positioned by its center point and length                          |
 
-All four shapes use the same 100 × 100 card coordinate system. This makes it easy to align them with horseshoes, states, names, icons, and other layout elements.
+All shapes use the same 100 × 100 card coordinate system. This makes it easy to align them with horseshoes, states, names, icons, and other layout elements.
 
 ## :material-horseshoe: Basic usage
 
@@ -32,11 +34,13 @@ A rectangle can use a fixed center position, width, and height. It can also use 
 
 A circle needs a center position and a radius. Define the radius in SVG units with `radius`, or use `radius_percent` to scale it relative to the card.
 
+A polygon needs at least three sides. Use `radius` to keep its regular proportions, or use `width` and `height` to fit an exact area. See [Polygon](polygon-tool.md) for choosing which corner or side faces upward.
+
 Horizontal and vertical lines both use a center position and a length. Their configuration is almost identical; only the section name changes. Horizontal lines belong in `hlines`, while vertical lines belong in `vlines`.
 
 Shapes can also be connected to an entity through `entity_index`. This allows color stops and animations to respond to the state of that entity.
 
-Color stops use `fill` for rectangles and arcs, and `stroke` for circles and lines by default. Select `show.item_style: colorstop` for hard value ranges or `show.item_style: colorstopgradient` for a blended color. Add the matching mode block to color the fill, stroke, or both.
+Color stops use `fill` for rectangles, polygons, and arcs, and `stroke` for circles and lines by default. Select `show.item_style: colorstop` for hard value ranges or `show.item_style: colorstopgradient` for a blended color. Add the matching mode block to color the fill, stroke, or both.
 
 ### Example definitions
 
@@ -144,6 +148,23 @@ Color stops use `fill` for rectangles and arcs, and `stroke` for circles and lin
           5: 'purple'
     ```
 
+=== "Polygon"
+    A polygon uses a center, a side count, and one sizing method:
+
+    ```yaml title="Hexagon" linenums="1"
+    - xpos: 50
+      ypos: 50
+      sides: 6
+      radius: 30
+      styles:
+        fill: var(--primary-color)
+        fill-opacity: 0.2
+        stroke: var(--primary-color)
+        stroke-width: 1
+    ```
+
+    See [Polygon](polygon-tool.md) for exact dimensions, orientation, color stops, and matching a polygon horseshoe.
+
 === "Horizontal Line"
     A horizontal line uses a center position and a length:
 
@@ -208,7 +229,7 @@ Color stops use `fill` for rectangles and arcs, and `stroke` for circles and lin
 
 ## :material-horseshoe: Configuration fields
 
-The required fields depend on the shape type. Rectangles use either fixed dimensions or `fit`, circles need a radius, and lines use a length.
+The required fields depend on the shape type. Rectangles use either fixed dimensions or `fit`, polygons use a radius or exact dimensions, circles need a radius, and lines use a length.
 
 === "Rectangle"
     | Field | Required | Default | Description |
@@ -242,6 +263,20 @@ The required fields depend on the shape type. Rectangles use either fixed dimens
 
     !!! note
         Use either `radius` or `radius_percent`.
+
+=== "Polygon"
+    | Field | Required | Default | Description |
+    | :---- | :------: | :------ | :---------- |
+    | `xpos` | :material-check: | | Horizontal center position |
+    | `ypos` | :material-check: | | Vertical center position |
+    | `sides` | :material-check: | | Number of sides; `3` or greater |
+    | `radius` | One size | | Distance from the center to a corner |
+    | `width` | One size | | Exact width; requires `height` |
+    | `height` | One size | | Exact height; requires `width` |
+    | `top` | :material-close: | `0` for odd sides; `0.5` for even sides | Corner or side position that faces upward |
+    | `entity_index` | :material-close: | Not set | Entity used by state-dependent features |
+    | `styles` | :material-close: | Default polygon style | SVG and CSS styling |
+    | `color_stops` | :material-close: | Not set | Uses the connected entity state to determine the shape color |
 
 === "Horizontal Line"
     | Field | Required | Default | Description |
@@ -294,6 +329,16 @@ Visual shapes are rendered as SVG elements and can therefore be styled with CSS 
     | `stroke` | Defines the outline color | `stroke: blue` |
     | `stroke-width` | Controls the outline width | `stroke-width: 2em` |
     | `opacity` | Controls the opacity of the entire circle | `opacity: 0.7` |
+    | `fill-opacity` | Controls the opacity of the fill | `fill-opacity: 0.5` |
+    | `stroke-opacity` | Controls the opacity of the outline | `stroke-opacity: 0.5` |
+
+=== "Polygon"
+    | Property | What it does | Example |
+    | :------- | :----------- | :------ |
+    | `fill` | Defines the fill color | `fill: red` |
+    | `stroke` | Defines the outline color | `stroke: blue` |
+    | `stroke-width` | Controls the outline width | `stroke-width: 2` |
+    | `opacity` | Controls the opacity of the complete polygon | `opacity: 0.7` |
     | `fill-opacity` | Controls the opacity of the fill | `fill-opacity: 0.5` |
     | `stroke-opacity` | Controls the opacity of the outline | `stroke-opacity: 0.5` |
 

--- a/docs/docs/tools/tools-overview.md
+++ b/docs/docs/tools/tools-overview.md
@@ -18,7 +18,7 @@ Card tools are the elements you add to a Flexible Horseshoe Card. Choose the too
 | You want to show | Use |
 | --- | --- |
 | Current state, name, area, or icon | [Entity tools](entities/entity-state-tool.md) |
-| A line, circle, arc, rectangle, or custom text | [Shapes](shapes/shapes-overview.md) |
+| A line, circle, arc, rectangle, polygon, or custom text | [Shapes](shapes/shapes-overview.md) |
 | A value on a circular scale | [Horseshoe](horseshoe/horseshoe-overview.md) |
 | Entity history or statistics | [Sparkline](sparkline/sparkline-overview.md) |
 | A button, toggle, selector, stepper, or slider | [Interactive controls](controls/controls-overview.md) |

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -240,11 +240,13 @@ nav:
           - Arc: tools/shapes/arc-tool.md
           - Circle: tools/shapes/circle-tool.md
           - Line: tools/shapes/line-tool.md
+          - Polygon: tools/shapes/polygon-tool.md
           - Rectangle: tools/shapes/rectangle-tool.md
           - Text: tools/shapes/text-tool.md
 
       - Horseshoe:
           - Overview: tools/horseshoe/horseshoe-overview.md
+          - Path shapes: tools/horseshoe/horseshoe-path-shapes.md
           - Scale and state: tools/horseshoe/horseshoe-scale-and-state.md
           - Tick marks and labels: tools/horseshoe/horseshoe-tick-marks-and-labels.md
 

--- a/examples/fhs-card-polygon-horseshoe-v1.yaml
+++ b/examples/fhs-card-polygon-horseshoe-v1.yaml
@@ -1,0 +1,154 @@
+fhs_card_polygon_horseshoe_v1:
+  template:
+    type: card
+
+  card:
+    default_entities:
+      - entity: fhs_input_number.showcase_polygon_state
+        slot: source
+        initial: 65
+        min: 0
+        max: 100
+        step: 1
+        unit: "%"
+        scope: global
+
+    layout:
+      aspectratio: 1/1.15
+
+      polygons:
+        - id: polygon-background
+          entity_index: source[0]
+          xpos: 50
+          ypos: 48
+          sides: 6
+          width: 72
+          height: 58
+          top: 0.5
+          show:
+            item_style: colorstopinterpolated
+          colorstopinterpolated:
+            fill: true
+            stroke: true
+          styles:
+            fill-opacity: 0.12
+            stroke-width: 1
+            stroke-opacity: 0.35
+          color_stops:
+            scales:
+              default:
+                min: 0
+                max: 100
+            colors:
+              0: "#1565c0"
+              35: "#42a5f5"
+              65: "#66bb6a"
+              85: "#f9a825"
+              100: "#d32f2f"
+
+      horseshoes:
+        - id: polygon-gauge
+          entity_index: source[0]
+          xpos: 50
+          ypos: 48
+          path:
+            type: polygon
+            sides: 6
+            width: 72
+            height: 58
+            top: 0.5
+
+          show:
+            horseshoe: true
+            horseshoe_style: colorstopgradient
+            scale_style: fixed
+            tickmarks: true
+            labels_at: ticks_major
+            label_badges: false
+
+          horseshoe_scale:
+            min: 0
+            max: 100
+            width: 3
+            color: var(--divider-color)
+            styles:
+              opacity: 0.45
+
+          horseshoe_state:
+            width: 7
+            linecap: round
+
+          horseshoe_tickmarks:
+            ticks_major:
+              ticksize: 25
+              width: 4
+              offset: 7
+              thickness: 1
+              styles:
+                fill: var(--primary-text-color)
+                opacity: 0.65
+            ticks_minor:
+              ticksize: 5
+              width: 2
+              offset: 7
+              thickness: 1
+              styles:
+                fill: var(--secondary-text-color)
+                opacity: 0.4
+
+          horseshoe_labels:
+            offset: 16
+            orientation: horizontal
+            styles:
+              font-size: 0.55em
+              fill: var(--secondary-text-color)
+
+          color_stops:
+            gap: 1
+            scales:
+              default:
+                min: 0
+                max: 100
+            colors:
+              0: "#1565c0"
+              35: "#42a5f5"
+              65: "#66bb6a"
+              85: "#f9a825"
+              100: "#d32f2f"
+
+      states:
+        - entity_index: source[0]
+          xpos: 50
+          ypos: 48
+          show:
+            uom: end
+          styles:
+            font-size: 1.4em
+            font-weight: bold
+
+      texts:
+        - xpos: 50
+          ypos: 6
+          text: Polygon shape and gauge
+          styles:
+            font-size: 1em
+            font-weight: bold
+            text-anchor: middle
+            dominant-baseline: central
+
+      controls:
+        - id: value
+          type: slider
+          entity_index: source[0]
+          xpos: 50
+          ypos: 98
+          width: 70
+          height: 7
+          interaction:
+            update_interval: 0
+          value:
+            show: false
+          show:
+            item_variant: single
+            item_viz: linear
+            item_style: ha

--- a/examples/view-fhs-horseshoe-path-shapes.yaml
+++ b/examples/view-fhs-horseshoe-path-shapes.yaml
@@ -42,6 +42,41 @@ sections:
         template:
           name: fhs_card_horseshoe_path_shape_v1
           variables:
+            - var_title: Rectangle roof
+            - var_path:
+                type: rectangle
+                width: 70
+                height: 46
+                radius: 5
+                start: 3.5
+                end: 1.5
+
+      - type: custom:flex-horseshoe-card
+        template:
+          name: fhs_card_horseshoe_path_shape_v1
+          variables:
+            - var_title: Triangle
+            - var_path:
+                type: polygon
+                sides: 3
+                radius: 34
+
+      - type: custom:flex-horseshoe-card
+        template:
+          name: fhs_card_horseshoe_path_shape_v1
+          variables:
+            - var_title: Hexagon
+            - var_path:
+                type: polygon
+                sides: 6
+                width: 68
+                height: 52
+                top: 0.5
+
+      - type: custom:flex-horseshoe-card
+        template:
+          name: fhs_card_horseshoe_path_shape_v1
+          variables:
             - var_title: Wave
             - var_path:
                 type: wave
@@ -72,3 +107,7 @@ sections:
                 type: infinity
                 radius_x: 34
                 radius_y: 22
+
+      - type: custom:flex-horseshoe-card
+        template:
+          name: fhs_card_polygon_horseshoe_v1

--- a/tests/card-domain-classes.test.js
+++ b/tests/card-domain-classes.test.js
@@ -450,6 +450,7 @@ test('CardConfig assigns stable ids throughout visible layout sections', () => {
     layout: {
       groups: [{}, { id: 'named' }],
       controls: [{}, { id: 'control' }],
+      polygons: [{}, { id: 'polygon' }],
       compounds: [{ lines: [{}, { id: 'line' }] }],
       masks: { mask: { circles: [{}] } },
       clips: {},
@@ -460,6 +461,7 @@ test('CardConfig assigns stable ids throughout visible layout sections', () => {
 
   assert.deepEqual(config.layout.groups.map((item) => item.id), ['0', 'named']);
   assert.deepEqual(config.layout.controls.map((item) => item.id), ['0', 'control']);
+  assert.deepEqual(config.layout.polygons.map((item) => item.id), ['0', 'polygon']);
   assert.deepEqual(config.layout.compounds[0].lines.map((item) => item.id), ['0', 'line']);
   assert.equal(config.layout.masks.mask.circles[0].id, '0');
 });
@@ -664,6 +666,7 @@ test('CardAnimations matches entity state and preserves reused styles and icons'
           { animation_id: 'status', styles: { stroke: 'red' } },
           { animation_id: 'status', reuse: true, styles: { opacity: 0.5 } },
         ],
+        polygons: [{ animation_id: 'surface', styles: { fill: 'green' } }],
         icons: [{ animation_id: 'main', icon: 'mdi:lightbulb', styles: { fill: 'yellow' } }],
       }],
     },
@@ -673,6 +676,7 @@ test('CardAnimations matches entity state and preserves reused styles and icons'
   animations.update(config, [{ state: 'on' }], templates, true);
 
   assert.deepEqual(animations.styles.lines.status, { stroke: 'red', opacity: '0.5' });
+  assert.deepEqual(animations.styles.polygons.surface, { fill: 'green' });
   assert.deepEqual(animations.styles.icons.main, { fill: 'yellow' });
   assert.equal(animations.styles.iconsIcon.main, 'mdi:lightbulb');
 });


### PR DESCRIPTION
## Summary

- document the Polygon layout tool from the user workflow
- document rectangle and polygon horseshoe paths with side numbering, `start`, `end`, `direction`, and `top`
- add triangle, hexagon, rectangle-roof, and exact polygon/horseshoe overlay examples
- add Polygon and path-shape pages to navigation and configuration references
- extend shared lifecycle regression coverage for polygon ids and animations

## Validation

- `npm run build` (304 tests, lint, rollup)
- `npx playwright test` (15 browser tests)
- local links in changed pages and all active Markdown navigation targets verified
- MkDocs build is handled by the separate documentation environment and is not installed in this container

Closes #614