### PR TITLE
feat: add Horseshoe V3 state marker configuration

### DIFF
--- a/src/horseshoe-gauge.js
+++ b/src/horseshoe-gauge.js
@@ -52,6 +52,7 @@ export default class HorseshoeGauge extends BaseTool {
       'horseshoe_position',
       'horseshoe_scale',
       'horseshoe_state',
+      'horseshoe_marker',
       'horseshoe_background',
       'horseshoe_labels',
       'horseshoe_tickmarks',
@@ -184,6 +185,10 @@ export default class HorseshoeGauge extends BaseTool {
       arc_degrees: itemConfig.arc_degrees,
       start_angle: itemConfig.start_angle,
     };
+
+    if (this.config.horseshoe_marker.attach_to === 'center' && sourcePath.type !== 'arc') {
+      throw new Error('[horseshoes] center-attached horseshoe_marker requires path.type arc');
+    }
 
     if (!PATH_TYPES.includes(sourcePath.type)) {
       throw new Error(`[horseshoes] path.type '${sourcePath.type}' is invalid [${PATH_TYPES.join(', ')}]`);

--- a/src/horseshoe-state.js
+++ b/src/horseshoe-state.js
@@ -32,6 +32,8 @@ export function normalizeBaseConfig(config, index, groupManager, colorStopMode) 
       horseshoe: true,
       horseshoe_style: "fixed",
       labels_at: "none",
+      state_progress: true,
+      state_marker: false,
       ...(config.show ?? {}),
     },
   };
@@ -136,6 +138,8 @@ export function normalizeRuntimeConfig(config, colorStopMode) {
     horseshoe: true,
     horseshoe_style: "fixed",
     labels_at: "none",
+    state_progress: true,
+    state_marker: false,
     ...(config.show ?? {}),
   };
 
@@ -186,6 +190,70 @@ export function normalizeRuntimeConfig(config, colorStopMode) {
     animation: DEFAULT_STATE_ANIMATION,
     ...(config.horseshoe_state ?? {}),
   };
+
+  // A path marker has a useful zero-config circle. Center attachment represents
+  // a pointer from the arc center and therefore needs an explicit icon shape.
+  const markerSource = config.horseshoe_marker ?? {};
+  const markerAttachTo = markerSource.attach_to ?? "path";
+  const horseshoeMarker = {
+    attach_to: markerAttachTo,
+    shape:
+      markerAttachTo === "path" && markerSource.icon === undefined
+        ? (markerSource.shape ?? "circle")
+        : markerSource.shape,
+    icon: markerSource.icon,
+    rotate: markerSource.rotate ?? 0,
+    offset: markerSource.offset ?? 0,
+    size:
+      markerAttachTo === "path"
+        ? (markerSource.size ?? horseshoeState.width)
+        : markerSource.size,
+    start_offset: markerSource.start_offset ?? 0,
+    end_offset: markerSource.end_offset ?? 0,
+  };
+
+  if (!["path", "center"].includes(horseshoeMarker.attach_to)) {
+    throw new Error(
+      `[horseshoes] horseshoe_marker.attach_to '${horseshoeMarker.attach_to}' is invalid [path, center]`,
+    );
+  }
+
+  if (
+    horseshoeMarker.shape !== undefined &&
+    !["circle", "triangle"].includes(horseshoeMarker.shape)
+  ) {
+    throw new Error(
+      `[horseshoes] horseshoe_marker.shape '${horseshoeMarker.shape}' is invalid [circle, triangle]`,
+    );
+  }
+
+  if (
+    markerSource.icon !== undefined &&
+    (typeof markerSource.icon !== "string" || markerSource.icon.trim() === "")
+  ) {
+    throw new Error("[horseshoes] horseshoe_marker.icon must be a non-empty string");
+  }
+
+  if (markerSource.icon !== undefined && markerSource.shape !== undefined) {
+    throw new Error("[horseshoes] horseshoe_marker accepts either icon or shape, not both");
+  }
+
+  if (horseshoeMarker.attach_to === "center" && horseshoeMarker.icon === undefined) {
+    throw new Error("[horseshoes] center-attached horseshoe_marker requires icon");
+  }
+
+  if (
+    horseshoeMarker.attach_to === "path" &&
+    (!Number.isFinite(Number(horseshoeMarker.size)) || Number(horseshoeMarker.size) <= 0)
+  ) {
+    throw new Error("[horseshoes] path-attached horseshoe_marker.size must be greater than zero");
+  }
+
+  ["rotate", "offset", "start_offset", "end_offset"].forEach((field) => {
+    if (!Number.isFinite(Number(horseshoeMarker[field]))) {
+      throw new Error(`[horseshoes] horseshoe_marker.${field} must be a number`);
+    }
+  });
 
   if (horseshoeState.mode === "stringstate_mode" || horseshoeState.mode === "stringstate_level") {
     horseshoeState.styles = {
@@ -387,6 +455,8 @@ export function normalizeRuntimeConfig(config, colorStopMode) {
         ...ConfigHelper.toStyleDict(horseshoeState.styles),
       },
     },
+
+    horseshoe_marker: horseshoeMarker,
 
     horseshoe_labels: {
       ...horseshoeLabels,

--- a/tests/horseshoe-path-adapter.test.js
+++ b/tests/horseshoe-path-adapter.test.js
@@ -362,6 +362,22 @@ test('major and minor tickmark visibility remains independently configurable', (
   assert.equal(horseshoe.pathElements.ticks.every((tick) => tick.layer === 'minor'), true);
 });
 
+test('center-attached state markers are limited to arc paths', () => {
+  const config = createConfig({ type: 'line', length: 80 });
+  Object.assign(config.layout.horseshoes[0], {
+    horseshoe_marker: {
+      attach_to: 'center',
+      icon: 'mdi:arrow-up-bold',
+    },
+  });
+  const [horseshoe] = HorseshoeGauge.setConfig(config, createTemplates(), 'card', createCard());
+
+  assert.throws(
+    () => horseshoe.updateRuntimeConfig(),
+    /center-attached horseshoe_marker requires path.type arc/,
+  );
+});
+
 test('color-stop segments share one normalized contract for scale and clipped state', () => {
   const config = createConfig({ type: 'line', length: 80 });
   Object.assign(config.layout.horseshoes[0], {

--- a/tests/horseshoe-state.test.js
+++ b/tests/horseshoe-state.test.js
@@ -21,6 +21,92 @@ test('minimal horseshoe configuration normalizes an empty color-stop configurati
   assert.equal(config.horseshoe_scale.min, 0);
   assert.equal(config.horseshoe_scale.max, 40);
   assert.equal(config.horseshoe_labels.distance_min, 0);
+  assert.equal(config.show.state_progress, true);
+  assert.equal(config.show.state_marker, false);
+  assert.deepEqual(config.horseshoe_marker, {
+    attach_to: 'path',
+    shape: 'circle',
+    icon: undefined,
+    rotate: 0,
+    offset: 0,
+    size: 12,
+    start_offset: 0,
+    end_offset: 0,
+  });
+});
+
+test('path marker configuration uses an explicit source and preserves signed placement', () => {
+  const baseConfig = normalizeBaseConfig({
+    horseshoe_scale: { min: 0, max: 100 },
+    horseshoe_state: { width: 8 },
+    horseshoe_marker: {
+      icon: 'mdi:dots-horizontal',
+      size: 10,
+      rotate: -90,
+      offset: -4,
+    },
+  }, 0, groupManager, 'dark');
+  const config = normalizeRuntimeConfig(baseConfig, 'dark');
+
+  assert.deepEqual(config.horseshoe_marker, {
+    attach_to: 'path',
+    shape: undefined,
+    icon: 'mdi:dots-horizontal',
+    rotate: -90,
+    offset: -4,
+    size: 10,
+    start_offset: 0,
+    end_offset: 0,
+  });
+});
+
+test('center marker configuration requires an icon and keeps both signed offsets', () => {
+  const baseConfig = normalizeBaseConfig({
+    horseshoe_scale: { min: 0, max: 100 },
+    horseshoe_marker: {
+      attach_to: 'center',
+      icon: 'mdi:arrow-up-bold',
+      rotate: 180,
+      start_offset: -2,
+      end_offset: 3,
+    },
+  }, 0, groupManager, 'dark');
+  const config = normalizeRuntimeConfig(baseConfig, 'dark');
+
+  assert.deepEqual(config.horseshoe_marker, {
+    attach_to: 'center',
+    shape: undefined,
+    icon: 'mdi:arrow-up-bold',
+    rotate: 180,
+    offset: 0,
+    size: undefined,
+    start_offset: -2,
+    end_offset: 3,
+  });
+});
+
+test('marker configuration rejects ambiguous, missing, and invalid values', () => {
+  const config = {
+    horseshoe_scale: { min: 0, max: 100, type: 'linear' },
+    colorstops: { scales: {}, colors: [] },
+  };
+
+  assert.throws(
+    () => normalizeRuntimeConfig({ ...config, horseshoe_marker: { attach_to: 'center' } }),
+    /center-attached horseshoe_marker requires icon/,
+  );
+  assert.throws(
+    () => normalizeRuntimeConfig({ ...config, horseshoe_marker: { icon: 'mdi:gauge', shape: 'circle' } }),
+    /either icon or shape/,
+  );
+  assert.throws(
+    () => normalizeRuntimeConfig({ ...config, horseshoe_marker: { shape: 'square' } }),
+    /shape 'square' is invalid/,
+  );
+  assert.throws(
+    () => normalizeRuntimeConfig({ ...config, horseshoe_marker: { size: 0 } }),
+    /size must be greater than zero/,
+  );
 });
 
 test('absolute mode validates a scale containing an undisplaced zero', () => {


### PR DESCRIPTION
## Summary

- add independent `show.state_progress` and `show.state_marker` defaults
- normalize path and center marker configuration in the horseshoe adapter
- reject invalid marker sources, dimensions, placement, and center attachment before rendering
- preserve the existing progress-only output for every current card

## Verification

- `npm test` (312 tests)
- `npm run lint`

Closes #627
