### PR TITLE
docs: explain horseshoe state markers for users

### DIFF
--- a/docs/docs/tools/horseshoe/horseshoe-overview.md
+++ b/docs/docs/tools/horseshoe/horseshoe-overview.md
@@ -1,7 +1,7 @@
 ---
 template: main.html
 title: Horseshoe Gauge Overview
-description: Build configurable Home Assistant horseshoe gauges with scales, state arcs, colors, tick marks, labels, and reusable layout definitions.
+description: Build configurable Home Assistant horseshoe gauges with scales, state progress, markers, colors, tick marks, labels, and reusable layout definitions.
 tags:
 - Section
 - Horseshoe
@@ -61,7 +61,8 @@ A horseshoe consists of several layers that can be shown, hidden, and styled ind
 | :------------------- | :-------------------------------------------------- | :------------------------------------------------------------- |
 | Horseshoe background | `horseshoe_background`                              | Adds an optional arc behind the full gauge.                    |
 | Scale                | `horseshoe_scale`                                   | Defines the value range, geometry, width, and base appearance. |
-| State                | `horseshoe_state`                                   | Shows the current entity value or mapped state.                |
+| State progress       | `horseshoe_state`                                   | Fills the path up to the current entity value or mapped state. |
+| State marker         | `horseshoe_marker`                                  | Marks the current value on the path or points to it from the center. |
 | Tick background      | `horseshoe_tickmarks.background`                    | Adds an optional background behind the tick layer.             |
 | Tick marks           | `horseshoe_tickmarks.ticks_major` and `ticks_minor` | Places numeric divisions along the scale.                      |
 | Label background     | `horseshoe_labels.background`                       | Adds an optional background behind the labels.                 |
@@ -97,6 +98,8 @@ Visibility and presentation settings are grouped under `show`.
 | :--------------------- | :------ | :------------------------------------------------ |
 | `horseshoe`            | `true`  | Shows or hides the entire horseshoe.              |
 | `horseshoe_style`      | `fixed` | Chooses fixed or color-stop-based state coloring. |
+| `state_progress`       | `true`  | Fills the path from its start to the current value. |
+| `state_marker`         | `false` | Shows the current value with a marker.            |
 | `horseshoe_background` | `none`  | Chooses the horseshoe background mode.            |
 | `tickmarks`            |         | Shows the configured major and minor tick marks.  |
 | `tick_background`      | `none`  | Chooses the tick background mode.                 |

--- a/docs/docs/tools/horseshoe/horseshoe-path-shapes.md
+++ b/docs/docs/tools/horseshoe/horseshoe-path-shapes.md
@@ -13,7 +13,7 @@ tags:
 
 A horseshoe can follow more than a circular arc. Use another path when a gauge should follow the edge of a panel, form a roof over a value, or become a triangle, hexagon, wave, spiral, or infinity symbol.
 
-The scale, state, colors, tick marks, labels, and animation continue to work along the selected shape.
+The scale, state progress, marker, colors, tick marks, labels, and animation continue to work along the selected shape. See [Horseshoe scale and state](horseshoe-scale-and-state.md#show-the-current-value-with-a-marker) for markers that follow a path or point to an arc from its center.
 
 <!-- Add horseshoe path shape showcase image -->
 

--- a/docs/docs/tools/horseshoe/horseshoe-scale-and-state.md
+++ b/docs/docs/tools/horseshoe/horseshoe-scale-and-state.md
@@ -1,7 +1,7 @@
 ---
 template: main.html
 title: Horseshoe Scale and State
-description: Configure horseshoe value ranges, scale geometry, state modes, mapped states, backgrounds, colors, and animations.
+description: Configure horseshoe value ranges, state progress, markers, mapped states, backgrounds, colors, and animations.
 tags:
 - Section
 - Horseshoe
@@ -69,6 +69,179 @@ horseshoe_state:
   styles:
     - fill: var(--primary-color)
 ```
+
+## :material-horseshoe: Show the current value with a marker
+
+A marker makes the current value visible at one exact position. It can replace the filled state path, mark the end of that path, or become a pointer from the center of a circular gauge.
+
+Choose the result with two independent `show` options:
+
+| Result | `state_progress` | `state_marker` |
+| --- | :---: | :---: |
+| Filled path | `true` | `false` |
+| Marker without a filled path | `false` | `true` |
+| Filled path ending in a marker | `true` | `true` |
+| Scale without a state indication | `false` | `false` |
+
+`state_progress` is `true` by default. `state_marker` is `false` by default, so existing horseshoes keep their normal filled state path.
+
+### Mark the value on the path
+
+This configuration replaces the filled state path with a circle at the current value:
+
+```yaml linenums="1"
+layout:
+  horseshoes:
+    - entity_index: 0
+      xpos: 50
+      ypos: 50
+      radius: 40
+      arc_degrees: 270
+
+      show:
+        state_progress: false
+        state_marker: true
+
+      horseshoe_scale:
+        min: 0
+        max: 100
+        width: 6
+
+      horseshoe_state:
+        width: 10
+```
+
+No `horseshoe_marker` block is needed for this basic result. The default marker is a circle with the same size as `horseshoe_state.width`.
+
+A path marker works on every horseshoe path shape. It follows an arc, line, rectangle, polygon, wave, spiral, or infinity path and moves to the current value.
+
+### Add a marker to the filled path
+
+Show both options when the marker should emphasize the end of the filled path. This example uses an icon and gives it a contrasting fill and border:
+
+```yaml linenums="1"
+layout:
+  horseshoes:
+    - entity_index: 0
+      xpos: 50
+      ypos: 50
+      path:
+        type: rectangle
+        width: 72
+        height: 48
+        radius: 5
+
+      show:
+        state_progress: true
+        state_marker: true
+
+      horseshoe_scale:
+        min: 0
+        max: 100
+        width: 6
+
+      horseshoe_state:
+        width: 8
+
+      horseshoe_marker:
+        attach_to: path
+        icon: mdi:dots-horizontal
+        size: 9
+        offset: 0
+        styles:
+          - fill: var(--card-background-color)
+          - stroke: var(--primary-text-color)
+          - stroke-width: 1
+```
+
+`offset: 0` keeps the marker centered on the path. Positive and negative values move it to either side, which is useful when the marker should remain beside the progress path instead of covering it.
+
+### Point to the value from the center
+
+A center marker turns an arc into a dial or VU-style gauge. The icon starts near the center and points toward the current value:
+
+```yaml linenums="1"
+layout:
+  horseshoes:
+    - entity_index: 0
+      xpos: 50
+      ypos: 50
+      radius: 40
+      arc_degrees: 270
+
+      show:
+        state_progress: false
+        state_marker: true
+
+      horseshoe_scale:
+        min: 0
+        max: 100
+        width: 6
+
+      horseshoe_state:
+        width: 8
+
+      horseshoe_marker:
+        attach_to: center
+        icon: mdi:arrow-up-thin
+        rotate: 0
+        aspectratio: 8
+        start_offset: 3
+        end_offset: -2
+        styles:
+          - fill: var(--primary-text-color)
+          - opacity: 0.8
+```
+
+Center attachment is available for arc paths. `start_offset` moves the beginning away from the center. A negative `end_offset` stops the pointer before the scale; a positive value extends it beyond the scale. Increase `aspectratio` to make the pointer narrower.
+
+An icon that naturally points upward uses `rotate: 0`. Use `rotate` to correct another icon before it follows the value. For example, `mdi:bow-arrow` points diagonally and uses `rotate: -45`.
+
+### Choose the marker shape
+
+| Source | Configuration | Result |
+| --- | --- | --- |
+| Circle | `shape: circle` | A round marker; this is the default for a path marker without an icon. |
+| Triangle | `shape: triangle` | An arrow-like marker that follows the path. |
+| Home Assistant icon | `icon: mdi:icon-name` | Uses any available Home Assistant or MDI icon. |
+| External SVG | `icon: url(/local/icons/marker.svg)` | Uses an SVG file as the marker. |
+| Image | `icon: url(/local/images/marker.png)` | Uses a PNG, WebP, or JPEG image. |
+
+Configure either `shape` or `icon`, not both. A center marker requires an icon.
+
+### Marker appearance
+
+Without marker styles, the marker uses the same current-state color, color stops, color filter, opacity, and animation as `horseshoe_state`. It therefore changes together with the filled state path.
+
+`horseshoe_marker.styles` gives the marker its own appearance when it needs to remain visible on top of the progress path:
+
+```yaml linenums="1"
+horseshoe_marker:
+  attach_to: path
+  shape: circle
+  size: 9
+  styles:
+    - fill: var(--card-background-color)
+    - stroke: var(--primary-text-color)
+    - stroke-width: 1
+```
+
+### Marker options
+
+| Field | Applies to | Required | Default | Description |
+| --- | --- | :---: | --- | --- |
+| `attach_to` | All markers | No | `path` | Places the marker on the path or, with `center`, between the center and an arc. |
+| `shape` | Path | No | `circle` when no icon is configured | Chooses `circle` or `triangle`. |
+| `icon` | Path and center | Center only | None | Uses a Home Assistant icon or `url(...)` file instead of a built-in shape. |
+| `size` | Path | No | `horseshoe_state.width` | Sets the marker length or circle diameter. |
+| `aspectratio` | Icons and triangle | No | `1` | Controls the marker proportions; larger values make it narrower. |
+| `rotate` | Icons and triangle | No | `0` | Corrects the marker's natural direction in degrees. |
+| `offset` | Path | No | `0` | Moves the marker to either side of the path. |
+| `start_offset` | Center | No | `0` | Moves the pointer start away from or behind the center. |
+| `end_offset` | Center | No | `0` | Stops the pointer before the scale or extends it beyond the scale. |
+| `styles` | All markers | No | Current `horseshoe_state` appearance | Gives the marker explicit SVG styles. |
+
+See the [state-marker showcase](https://github.com/AmoebeLabs/flex-horseshoe-card/blob/master/examples/view-fhs-horseshoe-state-markers.yaml) for complete arc, line, rectangle, and center-pointer cards.
 
 ## :material-horseshoe: State modes
 


### PR DESCRIPTION
## Summary

- explain state progress, state markers, and their combined result from the user's perspective
- provide complete configurations for a path marker, a progress marker, and an arc pointer
- document marker sources, appearance inheritance, options, defaults, and required fields
- link marker guidance from the horseshoe overview and path-shape page

## Verification

- `git diff --check`
- complete project build and marker browser tests passed during the preceding implementation PRs
- path and center markers were visually confirmed in Home Assistant

MkDocs is not installed in the development container, so the local documentation site build could not be run.

Closes #629
